### PR TITLE
Feat: 이메일 인증코드 발송 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 
     // Spring boot starter main
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    //thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Spring boot starter main
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/todayserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/todayserver/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.example.todayserver.domain.member.controller;
 
 import com.example.todayserver.domain.member.dto.EmailReqDto;
+import com.example.todayserver.domain.member.service.EmailService;
 import com.example.todayserver.domain.member.service.MemberService;
 import com.example.todayserver.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -11,13 +12,20 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @Tag(name = "Member", description = "회원가입,정보 관련 API")
-public class MemberController implements MemberControllerDocs{
+public class MemberController implements MemberControllerDocs {
 
     private final MemberService memberService;
+    private final EmailService emailService;
 
     @PostMapping("/members/email/check")
-    public ApiResponse<Void> checkEmail(@Valid @RequestBody EmailReqDto.EmailCheck dto){
+    public ApiResponse<Void> checkEmail(@Valid @RequestBody EmailReqDto.EmailCheck dto) {
         memberService.checkEmailDuplicate(dto);
+        return ApiResponse.success(null);
+    }
+
+    @PostMapping("/auth/email/verification-codes")
+    public ApiResponse<Void> sendEmailVerification(@Valid @RequestBody EmailReqDto.EmailCheck dto) {
+        emailService.sendVerificationEmail(dto.getEmail());
         return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/example/todayserver/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/com/example/todayserver/domain/member/controller/MemberControllerDocs.java
@@ -13,4 +13,10 @@ public interface MemberControllerDocs {
             description = "해당 이메일로 가입된 계정이 있는지 확인합니다."
     )
     ApiResponse<Void> checkEmail(@Valid @RequestBody EmailReqDto.EmailCheck dto);
+
+    @Operation(
+            summary = "이메일 인증코드 발송",
+            description = "해당 이메일로 인증코드 6자리를 발송합니다."
+    )
+    ApiResponse<Void> sendEmailVerification(@Valid @RequestBody EmailReqDto.EmailCheck dto);
 }

--- a/src/main/java/com/example/todayserver/domain/member/excpetion/AuthException.java
+++ b/src/main/java/com/example/todayserver/domain/member/excpetion/AuthException.java
@@ -1,0 +1,10 @@
+package com.example.todayserver.domain.member.excpetion;
+
+import com.example.todayserver.global.common.exception.BaseErrorCode;
+import com.example.todayserver.global.common.exception.CustomException;
+
+public class AuthException extends CustomException {
+    public AuthException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/member/excpetion/code/AuthErrorCode.java
+++ b/src/main/java/com/example/todayserver/domain/member/excpetion/code/AuthErrorCode.java
@@ -1,0 +1,19 @@
+package com.example.todayserver.domain.member.excpetion.code;
+
+import com.example.todayserver.global.common.exception.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+
+    CODE_ERROR(HttpStatus.SERVICE_UNAVAILABLE,
+            "EMAIL_VERIFY_503",
+            "현재 이메일 인증번호를 발급할 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/todayserver/domain/member/service/EmailService.java
+++ b/src/main/java/com/example/todayserver/domain/member/service/EmailService.java
@@ -1,0 +1,56 @@
+package com.example.todayserver.domain.member.service;
+
+import com.example.todayserver.domain.member.excpetion.AuthException;
+import com.example.todayserver.domain.member.excpetion.code.AuthErrorCode;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    public String sendVerificationEmail(String emailTo) {
+        String code = generateVerificationCode();
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(emailTo);
+            mimeMessageHelper.setSubject("[TO:DAY] 이메일 인증 코드 발송");
+            mimeMessageHelper.setText(createHtmlEmailBody(code),true);
+            mimeMessageHelper.setFrom(fromEmail);
+            javaMailSender.send(mimeMessage);
+
+            return code;
+        } catch (MessagingException e) {
+            throw new AuthException(AuthErrorCode.CODE_ERROR);
+        }
+    }
+
+    // 인증번호 생성
+    private String generateVerificationCode() {
+        return String.valueOf(100000 + new Random().nextInt(900000));
+    }
+
+    // 인증 이메일 뷰 생성
+    private String createHtmlEmailBody(String code) {
+        Context context = new Context();
+        context.setVariable("code", code);
+        return templateEngine.process("email_code", context);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -16,5 +16,18 @@ spring:
       hibernate:
         format_sql: true
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          timeout: 5000
+          starttls:
+            enable: true
+
 server:
   port: 8080

--- a/src/main/resources/templates/email_code.html
+++ b/src/main/resources/templates/email_code.html
@@ -1,0 +1,60 @@
+<table width="100%" cellpadding="0" cellspacing="0">
+    <tr>
+        <td align="center">
+            <table width="600" cellpadding="0" cellspacing="0"
+                   style="background-color:#ffffff; margin:40px 0; padding:40px;
+                          border-radius:8px; font-family:Arial, sans-serif;
+                          box-shadow:0 4px 10px rgba(0,0,0,0.08);">
+
+                <tr>
+                    <td align="center">
+                        <h1 style="margin:0; color:#333;">안녕하세요 👋</h1>
+                        <p style="margin-top:10px; font-size:16px; color:#555;">
+                            올인원 할일 관리 서비스 <strong>TO:DAY</strong>입니다.
+                        </p>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding:30px 0; text-align:center;">
+                        <p style="font-size:15px; color:#666;">
+                            서비스로 돌아가 아래 <strong>인증 코드</strong>를 입력해주세요.
+                        </p>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td align="center">
+                        <div style="border:1px solid #e0e0e0;
+                                    border-radius:6px;
+                                    padding:25px;
+                                    width:100%;
+                                    box-sizing:border-box;">
+                            <p style="margin:0; font-size:14px; color:#888;">
+                                회원가입 인증 코드
+                            </p>
+                            <p style="margin-top:15px;
+                                      font-size:28px;
+                                      letter-spacing:6px;
+                                      font-weight:bold;
+                                      color:#2f80ed;"
+                               th:text="${code}">
+                                123456
+                            </p>
+                        </div>
+                    </td>
+                </tr>
+
+                <tr>
+                    <td style="padding-top:30px; text-align:center;">
+                        <p style="font-size:13px; color:#999;">
+                            본 메일은 인증 요청에 의해 자동 발송되었습니다.<br>
+                            인증을 요청하지 않으셨다면 이 메일을 무시해주세요.
+                        </p>
+                    </td>
+                </tr>
+
+            </table>
+        </td>
+    </tr>
+</table>


### PR DESCRIPTION
## 관련 이슈
#8

<br>

## 작업 내용
이메일 인증코드 발송 API 구현
- 랜덤 6자리의 인증코드를 이메일로 전송
<img width="1010" height="473" alt="이메일_인증코드" src="https://github.com/user-attachments/assets/c7f4c8e8-6468-42fd-9abe-a6acb9c45cca" />

<br>

## 기타 (선택)
이메일 관련 .env 설정 필요(노션에 업로드)
