### PR TITLE
[Feat] 월별 일정 리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/example/todayserver/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/controller/ScheduleController.java
@@ -1,5 +1,7 @@
 package com.example.todayserver.domain.schedule.controller;
 
+import com.example.todayserver.domain.schedule.dto.EventMonthlyListRes;
+import com.example.todayserver.domain.schedule.dto.EventMonthlySearchReq;
 import com.example.todayserver.domain.schedule.dto.ScheduleCreateReq;
 import com.example.todayserver.domain.schedule.service.ScheduleService;
 import com.example.todayserver.global.common.response.ApiResponse;
@@ -27,5 +29,17 @@ public class ScheduleController {
         Long scheduleId = scheduleService.createSchedule(memberId, req);
 
         return ApiResponse.success("요청이 성공적으로 처리되었습니다.", scheduleId);
+    }
+
+    @Operation(summary = "월별 일정 조회", description = "연도/월/출처 필터 기준으로 일정 목록을 조회합니다.")
+    @GetMapping("/events")
+    public ApiResponse<EventMonthlyListRes> getMonthlyEvents(
+            @RequestParam("memberId") Long memberId,              // 임시 파라미터 추후 인증정보로 대체 예정
+            @Valid @ModelAttribute EventMonthlySearchReq req
+    ) {
+
+        EventMonthlyListRes res = scheduleService.getMonthlyEvents(memberId, req);
+
+        return ApiResponse.success(res);
     }
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/converter/EventMonthlyConverter.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/converter/EventMonthlyConverter.java
@@ -1,0 +1,46 @@
+package com.example.todayserver.domain.schedule.converter;
+
+import com.example.todayserver.domain.schedule.dto.EventMonthlyListRes;
+import com.example.todayserver.domain.schedule.entity.Schedule;
+import org.springframework.stereotype.Component;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Component
+public class EventMonthlyConverter {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;      // yyyy-MM-dd
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");  // HH:mm
+
+    // 월별 일정 리스트 -> EventMonthlyListRes로 변환
+    public EventMonthlyListRes toEventMonthlyListRes(String filter, List<Schedule> schedules
+    ) {
+        List<EventMonthlyListRes.EventDto> events = schedules.stream()
+                .map(this::toEventDto)
+                .toList();
+
+        return new EventMonthlyListRes(filter, events);
+    }
+
+    // Schedule 엔티티 1건 -> EventDto 로 변환
+    private EventMonthlyListRes.EventDto toEventDto(Schedule schedule) {
+        String date = schedule.getScheduleDate() != null ? schedule.getScheduleDate().format(DATE_FORMATTER) : null;
+
+        String startTime = schedule.getStartTime() != null ? schedule.getStartTime().format(TIME_FORMATTER) : null;
+
+        String endTime = schedule.getEndTime() != null ? schedule.getEndTime().format(TIME_FORMATTER) : null;
+
+        return new EventMonthlyListRes.EventDto(
+                schedule.getId(),
+                schedule.getTitle(),
+                schedule.getColor(),
+                schedule.getEmoji(),
+                schedule.isDone(),
+                date,
+                startTime,
+                endTime,
+                schedule.getSource()
+        );
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/converter/ScheduleCreateConverter.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/converter/ScheduleCreateConverter.java
@@ -5,6 +5,7 @@ import com.example.todayserver.domain.schedule.dto.ScheduleCreateReq;
 import com.example.todayserver.domain.schedule.dto.SubScheduleCreateReq;
 import com.example.todayserver.domain.schedule.entity.Schedule;
 import com.example.todayserver.domain.schedule.entity.SubSchedule;
+import com.example.todayserver.domain.schedule.enums.ScheduleSource;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -29,6 +30,7 @@ public class ScheduleCreateConverter {
                 .member(member)
                 .scheduleType(req.scheduleType())
                 .mode(req.mode())
+                .source(ScheduleSource.LOCAL)
                 .title(req.title())
                 .memo(req.memo())
                 .color(req.bgColor())

--- a/src/main/java/com/example/todayserver/domain/schedule/dto/EventMonthlyListRes.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/dto/EventMonthlyListRes.java
@@ -1,0 +1,48 @@
+package com.example.todayserver.domain.schedule.dto;
+
+import com.example.todayserver.domain.schedule.enums.ScheduleSource;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+public record EventMonthlyListRes(
+
+        @Schema(description = "조회에 사용된 필터", example = "ALL")
+        String filter,
+
+        @Schema(description = "월별 일정 목록")
+        List<EventDto> events
+) {
+
+    @Schema(description = "월별 일정 개별 정보")
+    public record EventDto(
+
+            @Schema(description = "일정 ID", example = "1")
+            Long id,
+
+            @Schema(description = "일정 제목", example = "설거지하기")
+            String title,
+
+            @Schema(description = "색상 HEX 값", example = "#5A5D62")
+            String color,
+
+            @Schema(description = "이모지", example = "🍽️")
+            String emoji,
+
+            @Schema(description = "완료 여부", example = "false")
+            boolean isDone,
+
+            @Schema(description = "일정 날짜 (yyyy-MM-dd)", example = "2026-01-01")
+            String date,
+
+            @Schema(description = "시작 시간 (HH:mm)", example = "11:00")
+            String startTime,
+
+            @Schema(description = "종료 시간 (HH:mm)", example = "13:00")
+            String endTime,
+
+            @Schema(description = "일정 출처", example = "GOOGLE")
+            ScheduleSource source
+    ) {
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/dto/EventMonthlySearchReq.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/dto/EventMonthlySearchReq.java
@@ -1,0 +1,32 @@
+package com.example.todayserver.domain.schedule.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "월별 일정 조회 요청")
+public record EventMonthlySearchReq(
+
+        @Schema(description = "조회 연도", example = "2026")
+        @NotNull(message = "year는 필수 값입니다.")
+        Integer year,
+
+        @Schema(description = "조회 월(1~12)", example = "1")
+        @NotNull(message = "month는 필수 값입니다.")
+        @Min(value = 1, message = "month는 1부터 12 사이의 값이어야 합니다.")
+        @Max(value = 12, message = "month는 1부터 12 사이의 값이어야 합니다.")
+        Integer month,
+
+        @Schema(description = "일정 출처 필터 (ALL, GOOGLE, NOTION, ICLOUD, CSV)", example = "ALL")
+        @Pattern(
+                regexp = "ALL|LOCAL|GOOGLE|NOTION|ICLOUD|CSV",
+                message = "filter는 ALL, LOCAL, GOOGLE, NOTION, ICLOUD, CSV 중 하나여야 합니다."
+        )
+        String filter,
+
+        @Schema(description = "지난 일정 숨기기 여부", example = "false")
+        Boolean hidePast
+) {
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/entity/Schedule.java
@@ -3,6 +3,7 @@ package com.example.todayserver.domain.schedule.entity;
 import com.example.todayserver.domain.member.entity.Member;
 import com.example.todayserver.domain.schedule.enums.Mode;
 import com.example.todayserver.domain.schedule.enums.RepeatType;
+import com.example.todayserver.domain.schedule.enums.ScheduleSource;
 import com.example.todayserver.domain.schedule.enums.ScheduleType;
 import com.example.todayserver.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -33,6 +34,10 @@ public class Schedule extends BaseEntity {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Mode mode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source", nullable = false, length = 20)
+    private ScheduleSource source;
 
     @Column(nullable = false, length = 100)
     private String title;

--- a/src/main/java/com/example/todayserver/domain/schedule/enums/ScheduleSource.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/enums/ScheduleSource.java
@@ -1,0 +1,9 @@
+package com.example.todayserver.domain.schedule.enums;
+
+public enum ScheduleSource {
+    LOCAL,
+    GOOGLE,
+    NOTION,
+    ICLOUD,
+    CSV
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/repository/ScheduleRepository.java
@@ -1,7 +1,29 @@
 package com.example.todayserver.domain.schedule.repository;
 
 import com.example.todayserver.domain.schedule.entity.Schedule;
+import com.example.todayserver.domain.schedule.enums.ScheduleSource;
+import com.example.todayserver.domain.schedule.enums.ScheduleType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+    // 월별 일정 데이터 전체 조회
+    List<Schedule> findByMemberIdAndScheduleTypeAndScheduleDateBetween(
+            Long memberId,
+            ScheduleType scheduleType,
+            LocalDate startDate,
+            LocalDate endDate
+    );
+
+
+    // 월별 일정 데이터 필터 조회
+    List<Schedule> findByMemberIdAndScheduleTypeAndScheduleDateBetweenAndSource(
+            Long memberId,
+            ScheduleType scheduleType,
+            LocalDate startDate,
+            LocalDate endDate,
+            ScheduleSource source
+    );
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/service/ScheduleService.java
@@ -3,10 +3,15 @@ package com.example.todayserver.domain.schedule.service;
 import com.example.todayserver.domain.member.entity.Member;
 import com.example.todayserver.domain.member.excpetion.code.MemberErrorCode;
 import com.example.todayserver.domain.member.repository.MemberRepository;
+import com.example.todayserver.domain.schedule.converter.EventMonthlyConverter;
 import com.example.todayserver.domain.schedule.converter.ScheduleCreateConverter;
+import com.example.todayserver.domain.schedule.dto.EventMonthlyListRes;
+import com.example.todayserver.domain.schedule.dto.EventMonthlySearchReq;
 import com.example.todayserver.domain.schedule.dto.ScheduleCreateReq;
 import com.example.todayserver.domain.schedule.entity.Schedule;
 import com.example.todayserver.domain.schedule.entity.SubSchedule;
+import com.example.todayserver.domain.schedule.enums.ScheduleSource;
+import com.example.todayserver.domain.schedule.enums.ScheduleType;
 import com.example.todayserver.domain.schedule.repository.ScheduleRepository;
 import com.example.todayserver.domain.schedule.repository.SubScheduleRepository;
 import com.example.todayserver.domain.schedule.validator.ScheduleCreateValidator;
@@ -15,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -24,6 +30,7 @@ public class ScheduleService {
     private final MemberRepository memberRepository;
     private final SubScheduleRepository subScheduleRepository;
     private final ScheduleCreateConverter scheduleCreateConverter;
+    private final EventMonthlyConverter eventMonthlyConverter;
     private final ScheduleCreateValidator scheduleCreateValidator;
 
     @Transactional
@@ -44,5 +51,65 @@ public class ScheduleService {
         }
 
         return schedule.getId();
+    }
+
+    // 월별 일정 리스트 조회
+    public EventMonthlyListRes getMonthlyEvents(Long memberId, EventMonthlySearchReq req) {
+        Integer year = req.year();
+        Integer month = req.month();
+
+        // filter가 null 또는 공백이면 ALL로 처리
+        String filterLabel = (req.filter() == null || req.filter().isBlank()) ? "ALL" : req.filter().toUpperCase();
+
+        // 해당 연/월의 1일 ~ 말일 계산
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.plusMonths(1).minusDays(1);
+
+        // 지난 일정 숨기기 여부 (null 이면 false)
+        boolean hidePast = Boolean.TRUE.equals(req.hidePast());
+
+        List<Schedule> schedules;
+
+        if ("ALL".equals(filterLabel)) {
+            // 한 달 일정 전체 조회
+            schedules = scheduleRepository.findByMemberIdAndScheduleTypeAndScheduleDateBetween(
+                    memberId,
+                    ScheduleType.EVENT,
+                    startDate,
+                    endDate
+            );
+        } else {
+            // 특정 출처만 조회 (GOOGLE, NOTION, ICLOUD, CSV, LOCAL)
+            ScheduleSource sourceFilter = ScheduleSource.valueOf(filterLabel);
+
+            schedules = scheduleRepository.findByMemberIdAndScheduleTypeAndScheduleDateBetweenAndSource(
+                    memberId,
+                    ScheduleType.EVENT,
+                    startDate,
+                    endDate,
+                    sourceFilter
+            );
+        }
+
+        // 지난 일정 숨기기 적용 (현재 월일 때만)
+        if (hidePast) {
+            LocalDate today = LocalDate.now();
+
+            boolean isCurrentMonth =
+                    year.equals(today.getYear()) &&
+                            month.equals(today.getMonthValue());
+
+            if (isCurrentMonth) {
+                schedules = schedules.stream()
+                        .filter(schedule -> {
+                            LocalDate date = schedule.getScheduleDate();
+
+                            // 오늘 이전 날짜면 숨김
+                            return !date.isBefore(today);
+                        })
+                        .toList();
+            }
+        }
+        return eventMonthlyConverter.toEventMonthlyListRes(filterLabel, schedules);
     }
 }


### PR DESCRIPTION
## 관련 이슈
#19 
<br>

## 작업 내용
- Schedule 엔티티에 source(일정 생성 경로) 필드 추가
- 일정/할일 직접 등록시 source=LOCAL 되도록 추가
- 월별 일정 조회 API 구현
<br>
 
## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
