### PR TITLE
[Feat] Schedule 엔티티 수정 및 월별 일정 완료 현황 API 구현

### DIFF
--- a/src/main/java/com/example/todayserver/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/controller/ScheduleController.java
@@ -1,5 +1,6 @@
 package com.example.todayserver.domain.schedule.controller;
 
+import com.example.todayserver.domain.schedule.dto.EventMonthlyCompletionRes;
 import com.example.todayserver.domain.schedule.dto.EventMonthlyListRes;
 import com.example.todayserver.domain.schedule.dto.EventMonthlySearchReq;
 import com.example.todayserver.domain.schedule.dto.ScheduleCreateReq;
@@ -8,6 +9,9 @@ import com.example.todayserver.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,6 +43,20 @@ public class ScheduleController {
     ) {
 
         EventMonthlyListRes res = scheduleService.getMonthlyEvents(memberId, req);
+
+        return ApiResponse.success(res);
+    }
+
+    @Operation(summary = "월별 일정 완료 현황 조회", description = "월별 일정 완료 현황을 조회합니다.")
+    @GetMapping("/events/completion")
+    public ApiResponse<EventMonthlyCompletionRes> getMonthlyEventCompletion(
+            @RequestParam("memberId") Long memberId,              // 임시 파라미터 추후 인증정보로 대체 예정
+            @RequestParam @NotNull @Min(1970) @Max(3000) Integer year,
+            @RequestParam @NotNull @Min(1) @Max(12) Integer month
+    ) {
+
+        EventMonthlyCompletionRes res =
+                scheduleService.getMonthlyEventCompletion(memberId, year, month);
 
         return ApiResponse.success(res);
     }

--- a/src/main/java/com/example/todayserver/domain/schedule/converter/EventMonthlyConverter.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/converter/EventMonthlyConverter.java
@@ -10,8 +10,8 @@ import java.util.List;
 @Component
 public class EventMonthlyConverter {
 
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;      // yyyy-MM-dd
-    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");  // HH:mm
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
     // 월별 일정 리스트 -> EventMonthlyListRes로 변환
     public EventMonthlyListRes toEventMonthlyListRes(String filter, List<Schedule> schedules
@@ -25,11 +25,17 @@ public class EventMonthlyConverter {
 
     // Schedule 엔티티 1건 -> EventDto 로 변환
     private EventMonthlyListRes.EventDto toEventDto(Schedule schedule) {
-        String date = schedule.getScheduleDate() != null ? schedule.getScheduleDate().format(DATE_FORMATTER) : null;
 
-        String startTime = schedule.getStartTime() != null ? schedule.getStartTime().format(TIME_FORMATTER) : null;
+        String startedAt = null;
+        String endedAt = null;
 
-        String endTime = schedule.getEndTime() != null ? schedule.getEndTime().format(TIME_FORMATTER) : null;
+        if (schedule.getStartedAt() != null) {
+            startedAt = schedule.getStartedAt().format(DATE_TIME_FORMATTER);
+        }
+
+        if (schedule.getEndedAt() != null) {
+            endedAt = schedule.getEndedAt().format(DATE_TIME_FORMATTER);
+        }
 
         return new EventMonthlyListRes.EventDto(
                 schedule.getId(),
@@ -37,9 +43,8 @@ public class EventMonthlyConverter {
                 schedule.getColor(),
                 schedule.getEmoji(),
                 schedule.isDone(),
-                date,
-                startTime,
-                endTime,
+                startedAt,
+                endedAt,
                 schedule.getSource()
         );
     }

--- a/src/main/java/com/example/todayserver/domain/schedule/converter/ScheduleCreateConverter.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/converter/ScheduleCreateConverter.java
@@ -8,8 +8,7 @@ import com.example.todayserver.domain.schedule.entity.SubSchedule;
 import com.example.todayserver.domain.schedule.enums.ScheduleSource;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
@@ -22,9 +21,8 @@ public class ScheduleCreateConverter {
 
     public Schedule toSchedule(ScheduleCreateReq req, Member member) {
 
-        LocalDate scheduleDate = resolveScheduleDate(req);
-        LocalTime startTime = parseTimeOrNull(req.startAt());
-        LocalTime endTime = parseTimeOrNull(req.endAt());
+        LocalDateTime startedAt = resolveStartedAt(req);
+        LocalDateTime endedAt = parseDateTimeOrNull(req.endAt());
 
         return Schedule.builder()
                 .member(member)
@@ -35,11 +33,10 @@ public class ScheduleCreateConverter {
                 .memo(req.memo())
                 .color(req.bgColor())
                 .emoji(req.emoji())
-                .scheduleDate(scheduleDate)
-                .startTime(startTime)
-                .endTime(endTime)
+                .startedAt(startedAt)
+                .endedAt(endedAt)
                 .repeatType(req.repeatType())
-                .durationMinutes(req.duration())
+                .durationMinutes(req.duration()) // EVENT 일 경우 null
                 .isDone(false) // 초기값 = false
                 .build();
     }
@@ -62,22 +59,22 @@ public class ScheduleCreateConverter {
                 .toList();
     }
 
-    // date 또는 startAt 기준으로 scheduleDate 계산
-    private LocalDate resolveScheduleDate(ScheduleCreateReq req) {
-        if (req.date() != null) {
-            return req.date();
-        }
+    // startedAt 계산
+    private LocalDateTime resolveStartedAt(ScheduleCreateReq req) {
         if (req.startAt() != null && !req.startAt().isBlank()) {
-            return LocalDate.parse(req.startAt(), DATE_TIME_FORMATTER);
+            return LocalDateTime.parse(req.startAt(), DATE_TIME_FORMATTER);
+        }
+        if (req.date() != null) {
+            return req.date().atStartOfDay(); // 해당 일자의 T00:00:00
         }
         return null;
     }
 
-    // LocalTime으로 파싱
-    private LocalTime parseTimeOrNull(String dateTimeText) {
+    // endedAt 파싱 (Event에서만 사용)
+    private LocalDateTime parseDateTimeOrNull(String dateTimeText) {
         if (dateTimeText == null || dateTimeText.isBlank()) {
             return null;
         }
-        return LocalTime.parse(dateTimeText, DATE_TIME_FORMATTER);
+        return LocalDateTime.parse(dateTimeText, DATE_TIME_FORMATTER);
     }
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/dto/EventMonthlyCompletionRes.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/dto/EventMonthlyCompletionRes.java
@@ -1,0 +1,27 @@
+package com.example.todayserver.domain.schedule.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record EventMonthlyCompletionRes(
+
+        @Schema(description = "조회 연도", example = "2026")
+        int year,
+
+        @Schema(description = "조회 월", example = "1")
+        int month,
+
+        @Schema(description = "이번 달 전체 일정(EVENT) 수", example = "10")
+        long totalCount,
+
+        @Schema(description = "완료한 일정(EVENT) 수", example = "1")
+        long completedCount
+) {
+    public static EventMonthlyCompletionRes of(
+            int year,
+            int month,
+            long totalCount,
+            long completedCount
+    ) {
+        return new EventMonthlyCompletionRes(year, month, totalCount, completedCount);
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/dto/EventMonthlyListRes.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/dto/EventMonthlyListRes.java
@@ -32,14 +32,11 @@ public record EventMonthlyListRes(
             @Schema(description = "완료 여부", example = "false")
             boolean isDone,
 
-            @Schema(description = "일정 날짜 (yyyy-MM-dd)", example = "2026-01-01")
-            String date,
+            @Schema(description = "일정 시작 일시 (yyyy-MM-dd HH:mm)", example = "2026-01-01 11:00")
+            String startedAt,
 
-            @Schema(description = "시작 시간 (HH:mm)", example = "11:00")
-            String startTime,
-
-            @Schema(description = "종료 시간 (HH:mm)", example = "13:00")
-            String endTime,
+            @Schema(description = "일정 종료 일시 (yyyy-MM-dd HH:mm)", example = "2026-01-01 13:00")
+            String endedAt,
 
             @Schema(description = "일정 출처", example = "GOOGLE")
             ScheduleSource source

--- a/src/main/java/com/example/todayserver/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/entity/Schedule.java
@@ -12,8 +12,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -51,14 +50,11 @@ public class Schedule extends BaseEntity {
     @Column(nullable = true, length = 10)
     private String emoji;
 
-    @Column(name = "schedule_date", nullable = true)
-    private LocalDate scheduleDate;
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
 
-    @Column(name = "start_time", nullable = true)
-    private LocalTime startTime;
-
-    @Column(name = "end_time", nullable = true)
-    private LocalTime endTime;
+    @Column(name = "ended_at")
+    private LocalDateTime endedAt;
 
     @Column(name = "repeat_type", nullable = true)
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/todayserver/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/repository/ScheduleRepository.java
@@ -5,25 +5,25 @@ import com.example.todayserver.domain.schedule.enums.ScheduleSource;
 import com.example.todayserver.domain.schedule.enums.ScheduleType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     // 월별 일정 데이터 전체 조회
-    List<Schedule> findByMemberIdAndScheduleTypeAndScheduleDateBetween(
+    List<Schedule> findByMemberIdAndScheduleTypeAndStartedAtBetween(
             Long memberId,
             ScheduleType scheduleType,
-            LocalDate startDate,
-            LocalDate endDate
+            LocalDateTime startedAtFrom,
+            LocalDateTime startedAtTo
     );
 
 
     // 월별 일정 데이터 필터 조회
-    List<Schedule> findByMemberIdAndScheduleTypeAndScheduleDateBetweenAndSource(
+    List<Schedule> findByMemberIdAndScheduleTypeAndStartedAtBetweenAndSource(
             Long memberId,
             ScheduleType scheduleType,
-            LocalDate startDate,
-            LocalDate endDate,
+            LocalDateTime startedAtFrom,
+            LocalDateTime startedAtTo,
             ScheduleSource source
     );
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/repository/ScheduleRepository.java
@@ -26,4 +26,20 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             LocalDateTime startedAtTo,
             ScheduleSource source
     );
+
+    // 월별 총 일정 개수 조회
+    long countByMemberIdAndScheduleTypeAndStartedAtBetween(
+            Long memberId,
+            ScheduleType scheduleType,
+            LocalDateTime startedAtFrom,
+            LocalDateTime startedAtTo
+    );
+
+    // 월별 완료된 일정 총 개수 조회
+    long countByMemberIdAndScheduleTypeAndStartedAtBetweenAndIsDoneTrue(
+            Long memberId,
+            ScheduleType scheduleType,
+            LocalDateTime startedAtFrom,
+            LocalDateTime startedAtTo
+    );
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/service/ScheduleService.java
@@ -120,4 +120,31 @@ public class ScheduleService {
         }
         return eventMonthlyConverter.toEventMonthlyListRes(filterLabel, schedules);
     }
+
+
+    // 월별 일정 완료 현황 조회
+    @Transactional(readOnly = true)
+    public EventMonthlyCompletionRes getMonthlyEventCompletion(Long memberId, int year, int month) {
+
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        LocalDateTime startedAtFrom = startDate.atStartOfDay();
+        LocalDateTime startedAtTo = endDate.atTime(23, 59, 59);
+
+        long total = scheduleRepository.countByMemberIdAndScheduleTypeAndStartedAtBetween(
+                memberId,
+                ScheduleType.EVENT,
+                startedAtFrom,
+                startedAtTo
+        );
+        long completed = scheduleRepository.countByMemberIdAndScheduleTypeAndStartedAtBetweenAndIsDoneTrue(
+                memberId,
+                ScheduleType.EVENT,
+                startedAtFrom,
+                startedAtTo
+        );
+
+        return EventMonthlyCompletionRes.of(year, month, total, completed);
+    }
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/service/ScheduleService.java
@@ -5,6 +5,7 @@ import com.example.todayserver.domain.member.excpetion.code.MemberErrorCode;
 import com.example.todayserver.domain.member.repository.MemberRepository;
 import com.example.todayserver.domain.schedule.converter.EventMonthlyConverter;
 import com.example.todayserver.domain.schedule.converter.ScheduleCreateConverter;
+import com.example.todayserver.domain.schedule.dto.EventMonthlyCompletionRes;
 import com.example.todayserver.domain.schedule.dto.EventMonthlyListRes;
 import com.example.todayserver.domain.schedule.dto.EventMonthlySearchReq;
 import com.example.todayserver.domain.schedule.dto.ScheduleCreateReq;
@@ -21,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -65,6 +67,10 @@ public class ScheduleService {
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = startDate.plusMonths(1).minusDays(1);
 
+        // DATETIME 범위 (startedAt 기준)
+        LocalDateTime startedAtFrom = startDate.atStartOfDay();
+        LocalDateTime startedAtTo = endDate.atTime(23, 59, 59);
+
         // 지난 일정 숨기기 여부 (null 이면 false)
         boolean hidePast = Boolean.TRUE.equals(req.hidePast());
 
@@ -72,21 +78,21 @@ public class ScheduleService {
 
         if ("ALL".equals(filterLabel)) {
             // 한 달 일정 전체 조회
-            schedules = scheduleRepository.findByMemberIdAndScheduleTypeAndScheduleDateBetween(
+            schedules = scheduleRepository.findByMemberIdAndScheduleTypeAndStartedAtBetween(
                     memberId,
                     ScheduleType.EVENT,
-                    startDate,
-                    endDate
+                    startedAtFrom,
+                    startedAtTo
             );
         } else {
             // 특정 출처만 조회 (GOOGLE, NOTION, ICLOUD, CSV, LOCAL)
             ScheduleSource sourceFilter = ScheduleSource.valueOf(filterLabel);
 
-            schedules = scheduleRepository.findByMemberIdAndScheduleTypeAndScheduleDateBetweenAndSource(
+            schedules = scheduleRepository.findByMemberIdAndScheduleTypeAndStartedAtBetweenAndSource(
                     memberId,
                     ScheduleType.EVENT,
-                    startDate,
-                    endDate,
+                    startedAtFrom,
+                    startedAtTo,
                     sourceFilter
             );
         }
@@ -102,8 +108,10 @@ public class ScheduleService {
             if (isCurrentMonth) {
                 schedules = schedules.stream()
                         .filter(schedule -> {
-                            LocalDate date = schedule.getScheduleDate();
-
+                            if (schedule.getStartedAt() == null) {
+                                return true;
+                            }
+                            LocalDate date = schedule.getStartedAt().toLocalDate();
                             // 오늘 이전 날짜면 숨김
                             return !date.isBefore(today);
                         })


### PR DESCRIPTION
## 관련 이슈
#19 
<br>

## 작업 내용
- Schedule 엔티티 수정
  - 일자, 시간 컬럼을 시각(datetime)구조로 변경 
- 월별 일정 완료 현황 조회 API 구현
<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
