### PR TITLE
[Feat] Google 캘린더 연동 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/config/ExternalClientRegistryConfig.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/config/ExternalClientRegistryConfig.java
@@ -1,0 +1,37 @@
+package com.example.todayserver.domain.schedule.connect.config;
+
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalCalendarClient;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalEventMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+public class ExternalClientRegistryConfig {
+
+    @Bean
+    public Map<ExternalProvider, ExternalCalendarClient> externalCalendarClientMap(
+            List<ExternalCalendarClient> clients
+    ) {
+        Map<ExternalProvider, ExternalCalendarClient> map = new EnumMap<>(ExternalProvider.class);
+        for (ExternalCalendarClient client : clients) {
+            map.put(client.provider(), client);
+        }
+        return map;
+    }
+
+    @Bean
+    public Map<ExternalProvider, ExternalEventMapper> externalEventMapperMap(
+            List<ExternalEventMapper> mappers
+    ) {
+        Map<ExternalProvider, ExternalEventMapper> map = new EnumMap<>(ExternalProvider.class);
+        for (ExternalEventMapper mapper : mappers) {
+            map.put(mapper.provider(), mapper);
+        }
+        return map;
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/config/GoogleOAuthProperties.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/config/GoogleOAuthProperties.java
@@ -1,0 +1,17 @@
+package com.example.todayserver.domain.schedule.connect.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "google.oauth2.calendar")
+public class GoogleOAuthProperties {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String scope;
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalIntegrationController.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalIntegrationController.java
@@ -1,0 +1,50 @@
+package com.example.todayserver.domain.schedule.connect.controller;
+
+import com.example.todayserver.domain.schedule.connect.dto.GoogleAuthorizeUrlRes;
+import com.example.todayserver.domain.schedule.connect.service.google.GoogleConnectService;
+import com.example.todayserver.global.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Preferences", description = "설정 관련 API")
+@RestController
+@RequestMapping("/api/v1/preferences/integrations")
+@RequiredArgsConstructor
+public class ExternalIntegrationController {
+
+    private final GoogleConnectService googleConnectService;
+
+    @Operation(
+            summary = "Google 캘린더 연동 인가 URL 발급",
+            description = "현재 로그인한 사용자의 Google 캘린더 연동을 위한 OAuth 인가 URL을 생성합니다."
+    )
+    @PostMapping("/google/authorize")
+    public ApiResponse<GoogleAuthorizeUrlRes> authorizeGoogle(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "id") Long memberId
+    ) {
+        GoogleAuthorizeUrlRes res =
+                googleConnectService.buildGoogleAuthorizeUrl(memberId);
+        return ApiResponse.success(res);
+    }
+
+    @Operation(
+            summary = "Google 캘린더 연동 콜백 처리",
+            description = "Google OAuth 콜백을 받아 Authorization Code를 토큰으로 교환하고, ExternalAccount에 저장합니다."
+    )
+    @GetMapping("/google/callback")
+    public ApiResponse<Void> callbackGoogle(
+            @RequestParam("code")
+            @Parameter(description = "Google OAuth Authorization Code", example = "4/0AfJohX...")
+            String code,
+
+            @AuthenticationPrincipal(expression = "id") Long memberId
+    ) {
+        googleConnectService.handleGoogleCallback(code, memberId);
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/converter/ScheduleConverter.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/converter/ScheduleConverter.java
@@ -1,0 +1,53 @@
+package com.example.todayserver.domain.schedule.connect.converter;
+
+import com.example.todayserver.domain.member.entity.Member;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.entity.Schedule;
+import com.example.todayserver.domain.schedule.enums.ScheduleSource;
+import com.example.todayserver.domain.schedule.enums.ScheduleType;
+
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class ScheduleConverter {
+    private ScheduleConverter() {}
+
+    private static final List<String> EVENT_COLOR_PALETTE = List.of(
+            "#F5DEFE", "#88A2C9", "#F0EFC4", "#8DE7C9", "#FBEBD5",
+            "#E7ECE1", "#F3DCBA", "#DAE1E8", "#FB8C54", "#858585",
+            "#D2F0FF", "#E6B6B6", "#FCE3E3", "#EBC99A", "#DCDCDC",
+            "#DEFEE2", "#AEDEAC", "#B396C6", "#FCDCE2", "#A0C9CE",
+            "#EDEDED", "#B1BAD4", "#F3C9B4", "#C7AFAF", "#A1E992",
+            "#F5DEFE", "#BE77C4", "#F0DEC4", "#698F95", "#F9BF6F",
+            "#D4FDE3", "#885959", "#B9DCFE", "#B87959", "#C3ADEC",
+            "#E2E2E2", "#A05858", "#F9AEAE", "#F7950C", "#C9ADD8",
+            "#A0C5AE", "#6CA669", "#A0B7B0", "#B1757F", "#A4DCC3",
+            "#F6FEDE", "#929BB3", "#B49789", "#B86969", "#B7FAAA",
+            "#D4EAFD", "#906294", "#A5937B", "#DBEBED", "#FAEEDD",
+            "#F9D8CF", "#D36FAB", "#275C8C", "#94C68A", "#EBE2A7",
+            "#A0BA7A", "#E3D8D8", "#C3C3C3", "#D9F5D3", "#F7F4FD"
+    );
+
+    private static String randomEventColor() {
+        int idx = ThreadLocalRandom.current().nextInt(EVENT_COLOR_PALETTE.size());
+        return EVENT_COLOR_PALETTE.get(idx);
+    }
+
+    public static Schedule fromExternalEvent(ExternalEventDto event, Member member, ScheduleSource source) {
+        return Schedule.builder()
+                .member(member)
+                .scheduleType(ScheduleType.EVENT)
+                .mode(null)
+                .source(source)
+                .title(event.title() == null || event.title().isBlank() ? "(제목 없음)" : event.title())
+                .memo(event.description())
+                .color(randomEventColor())
+                .emoji(null)
+                .startedAt(event.startedAt())
+                .endedAt(event.endedAt())
+                .repeatType(null)
+                .durationMinutes(null)
+                .isDone(false)
+                .build();
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/converter/ScheduleExternalConverter.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/converter/ScheduleExternalConverter.java
@@ -1,0 +1,66 @@
+package com.example.todayserver.domain.schedule.connect.converter;
+
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalSource;
+import com.example.todayserver.domain.schedule.connect.entity.ScheduleExternal;
+import com.example.todayserver.domain.schedule.connect.enums.ScheduleExternalVersionType;
+import com.example.todayserver.domain.schedule.entity.Schedule;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class ScheduleExternalConverter {
+
+    private ScheduleExternalConverter() {}
+
+    public static ScheduleExternal newMapping(
+            ExternalEventDto event,
+            ExternalSource source,
+            Schedule schedule,
+            ScheduleExternalVersionType versionType
+    ) {
+        return ScheduleExternal.builder()
+                .externalSource(source)
+                .schedule(schedule)
+                .externalEventId(event.externalEventId())
+                .versionType(versionType)
+                .versionKey(buildVersionKey(event, versionType))
+                .originUpdatedAt(event.originUpdatedAt())
+                .build();
+    }
+
+    public static String buildVersionKey(ExternalEventDto event, ScheduleExternalVersionType versionType) {
+        return switch (versionType) {
+            case ETAG -> notBlankElse(event.versionKey(), "");
+            case UPDATED_AT -> event.originUpdatedAt() == null ? "" : event.originUpdatedAt().toString();
+            case HASH -> sha256(
+                    safe(event.title())
+                            + "|" + safe(event.description())
+                            + "|" + safe(event.startedAt())
+                            + "|" + safe(event.endedAt())
+                            + "|" + safe(event.originUpdatedAt())
+            );
+        };
+    }
+
+    private static String notBlankElse(String v, String fallback) {
+        return (v != null && !v.isBlank()) ? v : fallback;
+    }
+
+    private static String safe(Object v) {
+        return v == null ? "" : v.toString();
+    }
+
+    private static String sha256(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : digest) sb.append(String.format("%02x", b));
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            return "";
+        }
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/dto/ExternalEventDto.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/dto/ExternalEventDto.java
@@ -1,0 +1,15 @@
+package com.example.todayserver.domain.schedule.connect.dto;
+
+import java.time.LocalDateTime;
+
+public record ExternalEventDto(
+        String externalEventId,
+        String title,
+        String description,
+        LocalDateTime startedAt,
+        LocalDateTime endedAt,
+        boolean allDay,
+        LocalDateTime originUpdatedAt,
+        String versionKey,
+        String rawJson
+) { }

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/dto/ExternalSourceDto.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/dto/ExternalSourceDto.java
@@ -1,0 +1,7 @@
+package com.example.todayserver.domain.schedule.connect.dto;
+
+public record ExternalSourceDto(
+        String sourceKey,
+        String sourceName,
+        String metaJson
+) {}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/dto/GoogleAuthorizeUrlRes.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/dto/GoogleAuthorizeUrlRes.java
@@ -1,0 +1,13 @@
+package com.example.todayserver.domain.schedule.connect.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Google 캘린더 연동 인가 URL 응답")
+public record GoogleAuthorizeUrlRes(
+        @Schema(
+                description = "프론트에서 이동할 Google OAuth 인가 URL",
+                example = "https://accounts.google.com/o/oauth2/v2/auth?client_id=..."
+        )
+        String authorizeUrl
+) {
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/dto/GoogleCalendarDto.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/dto/GoogleCalendarDto.java
@@ -1,0 +1,47 @@
+package com.example.todayserver.domain.schedule.connect.dto;
+
+import java.util.List;
+
+
+public final class GoogleCalendarDto {
+
+    private GoogleCalendarDto() {
+    }
+
+   // users/me/calendarList 응답
+    public record CalendarListResponse(
+            List<CalendarItem> items
+    ) { }
+
+    // 일정 단건
+    public record CalendarItem(
+            String id,              // calendarId
+            String summary,         // 캘린더 이름
+            String timeZone,        // 타임존
+            String backgroundColor  // 캘린더 색상 (옵션)
+    ) { }
+
+    // calendars/{calendarId}/events 응답
+    public record EventsResponse(
+            List<EventItem> items
+    ) { }
+
+    // 이벤트 단건
+    public record EventItem(
+            String id,
+            String summary,
+            String description,
+            EventDateTime start,
+            EventDateTime end,
+            String updated,   // RFC3339
+            String etag,
+            String iCalUID
+    ) { }
+
+    // 이벤트 시간
+    public record EventDateTime(
+            String dateTime,  // "2026-01-19T10:00:00+09:00"
+            String date,      // "2026-01-19" (종일 일정)
+            String timeZone
+    ) { }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/dto/GoogleTokenRes.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/dto/GoogleTokenRes.java
@@ -1,0 +1,34 @@
+package com.example.todayserver.domain.schedule.connect.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record GoogleTokenRes(
+        @Schema(description = "액세스 토큰", example = "ya29.a0AfB_byCDeFg...")
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @Schema(description = "액세스 토큰 만료까지 남은 시간(초)", example = "3599")
+        @JsonProperty("expires_in")
+        Long expiresIn,
+
+        @Schema(description = "리프레시 토큰 (처음 동의 시에만 내려올 수 있음)",
+                example = "1//0gAbCdEfGhIjKlMnOpQrStUvWxYz...")
+        @JsonProperty("refresh_token")
+        String refreshToken,
+
+        @Schema(description = "부여된 권한(scope) 목록",
+                example = "https://www.googleapis.com/auth/calendar.readonly")
+        @JsonProperty("scope")
+        String scope,
+
+        @Schema(description = "토큰 타입", example = "Bearer")
+        @JsonProperty("token_type")
+        String tokenType,
+
+        @Schema(description = "ID 토큰 (필요 시 구글 사용자 정보 파싱에 사용)",
+                example = "eyJhbGciOiJSUzI1NiIsImtpZCI6Ij...")
+        @JsonProperty("id_token")
+        String idToken
+) {
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/entity/ExternalAccount.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/entity/ExternalAccount.java
@@ -1,0 +1,82 @@
+package com.example.todayserver.domain.schedule.connect.entity;
+
+import com.example.todayserver.domain.member.entity.Member;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalAccountStatus;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalAuthType;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "external_account")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ExternalAccount extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, length = 20)
+    private ExternalProvider provider;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "auth_type", nullable = false, length = 20)
+    private ExternalAuthType authType;
+
+    @Lob
+    @Column(name = "access_token",  nullable = true)
+    private String accessToken;
+
+    @Lob
+    @Column(name = "refresh_token",  nullable = true)
+    private String refreshToken;
+
+    @Column(name = "expires_at",  nullable = true)
+    private LocalDateTime expiresAt;
+
+    //계정 관련 추가 정보 (구글 userId, scope, 이메일 등)를 암호화해서 JSON 형태로 저장할 때 사용)
+    @Lob
+    @Column(name = "credential_encrypted",  nullable = true)
+    private String credentialEncrypted;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ExternalAccountStatus status;
+
+    // 마지막으로 동기화를 수행한 시각
+    @Column(name = "last_synced_at")
+    private LocalDateTime lastSyncedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @OneToMany(mappedBy = "externalAccount", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ExternalSource> externalSources = new ArrayList<>();
+
+    public void updateTokens(String accessToken, String refreshToken, LocalDateTime expiresAt) {
+        this.accessToken = accessToken;
+        if (refreshToken != null && !refreshToken.isBlank()) {
+            this.refreshToken = refreshToken;
+        }
+        this.expiresAt = expiresAt;
+    }
+
+    public void updateStatus(ExternalAccountStatus status) {
+        this.status = status;
+    }
+
+    public void updateLastSyncedAt(LocalDateTime lastSyncedAt) {
+        this.lastSyncedAt = lastSyncedAt;
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/entity/ExternalSource.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/entity/ExternalSource.java
@@ -1,0 +1,43 @@
+package com.example.todayserver.domain.schedule.connect.entity;
+
+import com.example.todayserver.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Entity
+@Table(name = "external_source")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ExternalSource extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "source_key", nullable = false, length = 255)
+    private String sourceKey;
+
+    @Column(name = "source_name", nullable = false, length = 255)
+    private String sourceName;
+
+    // timeZone, color 등 원본 메타데이터(JSON 문자열)
+    @Column(name = "meta_json", columnDefinition = "json", nullable = true)
+    private String metaJson;
+
+    @Column(name = "sync_enabled", nullable = false)
+    private boolean syncEnabled;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "external_account_id", nullable = false)
+    private ExternalAccount externalAccount;
+
+    @OneToMany(mappedBy = "externalSource", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<ScheduleExternal> scheduleExternals = new ArrayList<>();
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/entity/ScheduleExternal.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/entity/ScheduleExternal.java
@@ -1,0 +1,43 @@
+package com.example.todayserver.domain.schedule.connect.entity;
+
+import com.example.todayserver.domain.schedule.entity.Schedule;
+import com.example.todayserver.domain.schedule.connect.enums.ScheduleExternalVersionType;
+import com.example.todayserver.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "schedule_external")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ScheduleExternal extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "external_event_id", nullable = false, length = 255)
+    private String externalEventId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "version_type", nullable = false, length = 20)
+    private ScheduleExternalVersionType versionType;
+
+    @Column(name = "version_key", nullable = false, length = 255)
+    private String versionKey;
+
+    @Column(name = "origin_updated_at", nullable = false)
+    private LocalDateTime originUpdatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "schedule_id", nullable = false)
+    private Schedule schedule;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "external_source_id", nullable = false)
+    private ExternalSource externalSource;
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/enums/ExternalAccountStatus.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/enums/ExternalAccountStatus.java
@@ -1,0 +1,7 @@
+package com.example.todayserver.domain.schedule.connect.enums;
+
+public enum ExternalAccountStatus {
+    CONNECTED,
+    DISCONNECTED,
+    ERROR
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/enums/ExternalAuthType.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/enums/ExternalAuthType.java
@@ -1,0 +1,6 @@
+package com.example.todayserver.domain.schedule.connect.enums;
+
+public enum ExternalAuthType {
+    OAUTH,
+    ICS
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/enums/ExternalProvider.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/enums/ExternalProvider.java
@@ -1,0 +1,7 @@
+package com.example.todayserver.domain.schedule.connect.enums;
+
+public enum ExternalProvider {
+    GOOGLE,
+    NOTION,
+    ICLOUD
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/enums/ScheduleExternalVersionType.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/enums/ScheduleExternalVersionType.java
@@ -1,0 +1,7 @@
+package com.example.todayserver.domain.schedule.connect.enums;
+
+public enum ScheduleExternalVersionType {
+    ETAG,
+    HASH,
+    UPDATED_AT
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ExternalAccountRepository.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ExternalAccountRepository.java
@@ -1,0 +1,19 @@
+package com.example.todayserver.domain.schedule.connect.repository;
+
+import com.example.todayserver.domain.member.entity.Member;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalAccountStatus;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ExternalAccountRepository extends JpaRepository<ExternalAccount, Long> {
+    // 특정 사용자+특정 Provider 연동 계정 조회
+    Optional<ExternalAccount> findByMemberAndProvider(Member member, ExternalProvider provider);
+
+    Optional<ExternalAccount> findByMemberIdAndProviderAndStatus(
+            Long memberId, ExternalProvider provider, ExternalAccountStatus status
+    );
+
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ExternalSourceRepository.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ExternalSourceRepository.java
@@ -1,0 +1,20 @@
+package com.example.todayserver.domain.schedule.connect.repository;
+
+import com.example.todayserver.domain.schedule.connect.entity.ExternalSource;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ExternalSourceRepository extends JpaRepository<ExternalSource, Long> {
+    Optional<ExternalSource> findByExternalAccountIdAndSourceKey(Long externalAccountId, String sourceKey);
+
+    @Query("""
+           select s
+           from ExternalSource s
+           where s.externalAccount.id = :externalAccountId
+             and s.syncEnabled = true
+           """)
+    List<ExternalSource> findEnabledByAccount(Long externalAccountId);
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ScheduleExternalRepository.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ScheduleExternalRepository.java
@@ -1,0 +1,15 @@
+package com.example.todayserver.domain.schedule.connect.repository;
+
+import com.example.todayserver.domain.schedule.connect.entity.ScheduleExternal;
+import com.example.todayserver.domain.schedule.connect.enums.ScheduleExternalVersionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ScheduleExternalRepository extends JpaRepository<ScheduleExternal, Long> {
+    Optional<ScheduleExternal> findByExternalSourceIdAndExternalEventIdAndVersionType(
+            Long externalSourceId,
+            String externalEventId,
+            ScheduleExternalVersionType versionType
+    );
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/ExternalSyncAsyncService.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/ExternalSyncAsyncService.java
@@ -1,0 +1,18 @@
+package com.example.todayserver.domain.schedule.connect.service;
+
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExternalSyncAsyncService {
+
+    private final ExternalSyncService externalSyncService;
+
+    @Async
+    public void syncMonth(Long memberId, ExternalProvider provider, int year, int month) {
+        externalSyncService.syncMonth(memberId, provider, year, month);
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/ExternalSyncService.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/ExternalSyncService.java
@@ -1,0 +1,143 @@
+package com.example.todayserver.domain.schedule.connect.service;
+
+import com.example.todayserver.domain.member.entity.Member;
+import com.example.todayserver.domain.member.repository.MemberRepository;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalSourceDto;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalSource;
+import com.example.todayserver.domain.schedule.connect.entity.ScheduleExternal;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalAccountStatus;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.enums.ScheduleExternalVersionType;
+import com.example.todayserver.domain.schedule.connect.repository.ExternalAccountRepository;
+import com.example.todayserver.domain.schedule.connect.repository.ExternalSourceRepository;
+import com.example.todayserver.domain.schedule.connect.repository.ScheduleExternalRepository;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalCalendarClient;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalEventMapper;
+import com.example.todayserver.domain.schedule.entity.Schedule;
+import com.example.todayserver.domain.schedule.repository.ScheduleRepository;
+import com.example.todayserver.global.common.exception.CustomException;
+import com.example.todayserver.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExternalSyncService {
+
+    private final ExternalAccountRepository externalAccountRepository;
+    private final ExternalSourceRepository externalSourceRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final ScheduleExternalRepository scheduleExternalRepository;
+    private final MemberRepository memberRepository;
+
+    private final Map<ExternalProvider, ExternalCalendarClient> clientMap;
+    private final Map<ExternalProvider, ExternalEventMapper> mapperMap;
+
+    @Transactional
+    public void syncMonth(Long memberId, ExternalProvider provider, int year, int month) {
+        log.info("[ExternalSync][START] memberId={}, provider={}, year={}, month={}",
+                memberId, provider, year, month);
+
+        try {
+            // 연동 계정 확인
+            ExternalAccount account = externalAccountRepository
+                    .findByMemberIdAndProviderAndStatus(memberId, provider, ExternalAccountStatus.CONNECTED)
+                    .orElseThrow(() -> new CustomException(ErrorCode.EXTERNAL_ACCOUNT_NOT_FOUND));
+
+            // provider에 맞는 client / mapper 선택
+            ExternalCalendarClient client = clientMap.get(provider);
+            if (client == null) throw new CustomException(ErrorCode.EXTERNAL_CLIENT_NOT_REGISTERED);
+
+            ExternalEventMapper mapper = mapperMap.get(provider);
+            if (mapper == null) throw new CustomException(ErrorCode.EXTERNAL_MAPPER_NOT_REGISTERED);
+
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.INVALID_REQUEST));
+
+            // 외부 소스 목록 조회 및 저장(없으면 생성)
+            List<ExternalSourceDto> sourceDtos = client.fetchSources(account);
+            for (ExternalSourceDto dto : sourceDtos) {
+                externalSourceRepository.findByExternalAccountIdAndSourceKey(account.getId(), dto.sourceKey())
+                        .orElseGet(() -> externalSourceRepository.save(
+                                ExternalSource.builder()
+                                        .externalAccount(account)
+                                        .sourceKey(dto.sourceKey())
+                                        .sourceName(dto.sourceName())
+                                        .metaJson(dto.metaJson())
+                                        .syncEnabled(true)
+                                        .build()
+                        ));
+            }
+
+            // 이번 달 기간 계산
+            LocalDateTime from = YearMonth.of(year, month).atDay(1).atStartOfDay();
+            LocalDateTime to = YearMonth.of(year, month).atEndOfMonth().atTime(23, 59, 59);
+
+            // 이벤트 조회 및 (중복 제외) 저장 로직
+            List<ExternalSource> enabledSources = externalSourceRepository.findEnabledByAccount(account.getId());
+
+            int fetchedSources = enabledSources.size();
+            int fetchedEventsTotal = 0;
+            int skippedDuplicated = 0;
+            int newEventsDetected = 0;
+
+            for (ExternalSource source : enabledSources) {
+                List<ExternalEventDto> events = client.fetchEvents(account, source, from, to);
+                fetchedEventsTotal += events.size();
+
+                for (ExternalEventDto event : events) {
+                    ScheduleExternalVersionType versionType = mapper.versionType();
+
+                    boolean exists = scheduleExternalRepository
+                            .findByExternalSourceIdAndExternalEventIdAndVersionType(
+                                    source.getId(),
+                                    event.externalEventId(),
+                                    versionType
+                            )
+                            .isPresent();
+
+                    if (exists) {
+                        skippedDuplicated++;
+                        continue;
+                    }
+
+                    newEventsDetected++;
+
+                    // 신규 이벤트 ->  Schedule 저장
+                     Schedule schedule = mapper.toSchedule(event, member);
+                     scheduleRepository.save(schedule);
+
+                     ScheduleExternal mapping = mapper.toScheduleExternal(event, source, schedule);
+                     scheduleExternalRepository.save(mapping);
+                }
+            }
+
+            // 마지막 동기화 시각 기록
+            account.updateLastSyncedAt(LocalDateTime.now());
+
+            log.info("[ExternalSync][SUCCESS] memberId={}, provider={}, year={}, month={}, sources={}, events={}, newEvents={}, skippedDuplicated={}",
+                    memberId, provider, year, month, fetchedSources, fetchedEventsTotal, newEventsDetected, skippedDuplicated);
+
+        } catch (CustomException e) {
+            log.error("[ExternalSync][FAIL] memberId={}, provider={}, year={}, month={}, errorCode={}, message={}",
+                    memberId, provider, year, month, e.getErrorCode(), e.getMessage());
+            throw e;
+
+        } catch (Exception e) {
+            // 예상 못한 예외는 원인 추적을 위해 stacktrace 포함
+            log.error("[ExternalSync][FAIL] memberId={}, provider={}, year={}, month={}, unexpectedError={}",
+                    memberId, provider, year, month, e.toString(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/core/ExternalCalendarClient.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/core/ExternalCalendarClient.java
@@ -1,0 +1,26 @@
+package com.example.todayserver.domain.schedule.connect.service.core;
+
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalSourceDto;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalSource;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ExternalCalendarClient {
+    // 외부 플랫폼
+    ExternalProvider provider();
+
+    // 외부 서비스에 존재하는 캘린더/DB/보드 목록 조회
+    List<ExternalSourceDto> fetchSources(ExternalAccount account);
+
+    // 일정 기간동안의 이벤트 조회
+    List<ExternalEventDto> fetchEvents(
+            ExternalAccount account,
+            ExternalSource source,
+            LocalDateTime from,
+            LocalDateTime to
+    );
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/core/ExternalEventMapper.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/core/ExternalEventMapper.java
@@ -1,0 +1,21 @@
+package com.example.todayserver.domain.schedule.connect.service.core;
+
+import com.example.todayserver.domain.member.entity.Member;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalSource;
+import com.example.todayserver.domain.schedule.connect.entity.ScheduleExternal;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.enums.ScheduleExternalVersionType;
+import com.example.todayserver.domain.schedule.entity.Schedule;
+
+// 외부에서 가져온 데이터를 Schedule 구조로 변환
+public interface ExternalEventMapper {
+    ExternalProvider provider();
+
+    ScheduleExternalVersionType versionType();
+
+    Schedule toSchedule(ExternalEventDto event, Member member);
+
+    // 외부 이벤트를 내부 Schedule과 매핑하기 위한 ScheduleExternal 생성용 데이터
+    ScheduleExternal toScheduleExternal(ExternalEventDto event, ExternalSource source, Schedule schedule);
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/core/ExternalOAuthClient.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/core/ExternalOAuthClient.java
@@ -1,0 +1,6 @@
+package com.example.todayserver.domain.schedule.connect.service.core;
+
+public interface ExternalOAuthClient {
+    String buildAuthorizeUrl(String state);
+    Object exchangeCodeForToken(String code);
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/google/GoogleCalendarClient.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/google/GoogleCalendarClient.java
@@ -1,0 +1,224 @@
+package com.example.todayserver.domain.schedule.connect.service.google;
+
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalSourceDto;
+import com.example.todayserver.domain.schedule.connect.dto.GoogleCalendarDto;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalSource;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalCalendarClient;
+import com.example.todayserver.global.common.exception.CustomException;
+import com.example.todayserver.global.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Component
+public class GoogleCalendarClient implements ExternalCalendarClient {
+
+    private static final String BASE_URL = "https://www.googleapis.com/calendar/v3";
+
+    @Qualifier("googleCalendarWebClient")
+    private final WebClient webClient;
+
+    public GoogleCalendarClient(@Qualifier("googleCalendarWebClient") WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    @Override
+    public ExternalProvider provider() {
+        return ExternalProvider.GOOGLE;
+    }
+
+    // 캘린더 목록 조회
+    @Override
+    public List<ExternalSourceDto> fetchSources(ExternalAccount account) {
+        try {
+            String url = "/users/me/calendarList";
+
+            GoogleCalendarDto.CalendarListResponse body = webClient.get()
+                    .uri(url)
+                    .headers(h -> h.setBearerAuth(getAccessToken(account)))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, resp ->
+                            resp.bodyToMono(String.class)
+                                    .defaultIfEmpty("")
+                                    .flatMap(errorBody -> {
+                                        log.error("[GoogleCalendar] fetchSources failed status={} body={}",
+                                                resp.statusCode(), errorBody);
+                                        return Mono.error(new CustomException(ErrorCode.EXTERNAL_API_ERROR));
+                                    })
+                    )
+                    .bodyToMono(GoogleCalendarDto.CalendarListResponse.class)
+                    .block();
+
+            List<GoogleCalendarDto.CalendarItem> items =
+                    body != null && body.items() != null ? body.items() : List.of();
+
+            // 홀리데이 캘린더 제외
+            List<GoogleCalendarDto.CalendarItem> filtered = items.stream()
+                    .filter(item -> !isHolidayCalendar(item))
+                    .toList();
+
+            log.info("[GoogleCalendar] fetchSources success accountId={} count={} (filtered={})",
+                    account.getId(), items.size(), filtered.size());
+
+            return filtered.stream()
+                    .map(item -> new ExternalSourceDto(
+                            item.id(),
+                            item.summary(),
+                            buildSourceMetaJson(item)
+                    ))
+                    .toList();
+
+        } catch (CustomException e) {
+            throw e;
+
+        } catch (Exception e) {
+            log.error("[GoogleCalendar] fetchSources failed", e);
+            throw new CustomException(ErrorCode.EXTERNAL_API_ERROR);
+        }
+    }
+
+    private boolean isHolidayCalendar(GoogleCalendarDto.CalendarItem item) {
+        String id = Optional.ofNullable(item.id()).orElse("").toLowerCase();
+        String summary = Optional.ofNullable(item.summary()).orElse("").toLowerCase();
+
+        if (id.contains("#holiday@group.v.calendar.google.com")) return true;
+        if (id.contains("holiday")) return true;
+
+        if (summary.contains("holiday")) return true;
+        if (summary.contains("휴일")) return true;
+
+        return false;
+    }
+
+    // 이벤트 목록 조회
+    @Override
+    public List<ExternalEventDto> fetchEvents(ExternalAccount account, ExternalSource source, LocalDateTime from, LocalDateTime to
+    ) {
+        try {
+            String calendarId = source.getSourceKey();
+
+            // 시간 값을 UTC 'Z' 형식으로 변환
+            String timeMin = formatRfc3339(from);
+            String timeMax = formatRfc3339(to);
+
+            java.net.URI uri = UriComponentsBuilder
+                    .fromHttpUrl(BASE_URL + "/calendars/{calendarId}/events")
+                    .queryParam("singleEvents", "true")
+                    .queryParam("orderBy", "startTime")
+                    .queryParam("timeMin", timeMin)
+                    .queryParam("timeMax", timeMax)
+                    .buildAndExpand(calendarId)
+                    .toUri();
+
+            log.info("[GoogleCalendar] Final Request URI: {}", uri);
+
+            GoogleCalendarDto.EventsResponse body = webClient.get()
+                    .uri(uri)
+                    .headers(h -> h.setBearerAuth(getAccessToken(account)))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, resp ->
+                            resp.bodyToMono(String.class)
+                                    .defaultIfEmpty("")
+                                    .flatMap(errorBody -> {
+                                        log.error("[GoogleCalendar] fetchEvents failed calendarId={} status={} body={}",
+                                                source.getSourceKey(), resp.statusCode(), errorBody);
+                                        return Mono.error(new CustomException(ErrorCode.EXTERNAL_API_ERROR));
+                                    })
+                    )
+                    .bodyToMono(GoogleCalendarDto.EventsResponse.class)
+                    .block();
+
+            List<GoogleCalendarDto.EventItem> items =
+                    body != null && body.items() != null ? body.items() : List.of();
+
+            log.info("[GoogleCalendar] fetchEvents success calendarId={} count={}",
+                    source.getSourceKey(), items.size());
+
+            return items.stream()
+                    .map(this::toExternalEventDto)
+                    .toList();
+
+        } catch (CustomException e) {
+            throw e;
+
+        } catch (Exception e) {
+            log.error("[GoogleCalendar] fetchEvents failed calendarId={}", source.getSourceKey(), e);
+            throw new CustomException(ErrorCode.EXTERNAL_API_ERROR);
+        }
+    }
+
+    private String getAccessToken(ExternalAccount account) {
+        String token = Optional.ofNullable(account.getAccessToken())
+                .map(String::trim)
+                .orElse("");
+
+        if (token.isEmpty()) {
+            throw new CustomException(ErrorCode.EXTERNAL_ACCESS_TOKEN_NOT_FOUND);
+        }
+        return token;
+    }
+
+    private String formatRfc3339(LocalDateTime dateTime) {
+        return dateTime
+                .atZone(ZoneId.of("Asia/Seoul"))
+                .withZoneSameInstant(ZoneId.of("UTC"))
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'"));
+    }
+
+    private String buildSourceMetaJson(GoogleCalendarDto.CalendarItem item) {
+        return String.format(
+                "{\"timeZone\":\"%s\",\"backgroundColor\":\"%s\"}",
+                Optional.ofNullable(item.timeZone()).orElse(""),
+                Optional.ofNullable(item.backgroundColor()).orElse("")
+        );
+    }
+
+    private ExternalEventDto toExternalEventDto(GoogleCalendarDto.EventItem event) {
+        LocalDateTime startedAt = toLocalDateTime(event.start());
+        LocalDateTime endedAt = toLocalDateTime(event.end());
+        boolean allDay = isAllDay(event.start());
+
+        LocalDateTime originUpdatedAt =
+                event.updated() != null
+                        ? OffsetDateTime.parse(event.updated()).toLocalDateTime()
+                        : startedAt;
+
+        String versionKey = event.etag() != null ? event.etag() : event.iCalUID();
+
+        return new ExternalEventDto(
+                event.id(),
+                event.summary(),
+                event.description(),
+                startedAt,
+                endedAt,
+                allDay,
+                originUpdatedAt,
+                versionKey,
+                null
+        );
+    }
+
+    private LocalDateTime toLocalDateTime(GoogleCalendarDto.EventDateTime src) {
+        if (src == null) return null;
+        if (src.dateTime() != null) return OffsetDateTime.parse(src.dateTime()).toLocalDateTime();
+        if (src.date() != null) return LocalDate.parse(src.date()).atStartOfDay();
+        return null;
+    }
+
+    private boolean isAllDay(GoogleCalendarDto.EventDateTime src) {
+        return src != null && src.date() != null && src.dateTime() == null;
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/google/GoogleConnectService.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/google/GoogleConnectService.java
@@ -1,0 +1,94 @@
+package com.example.todayserver.domain.schedule.connect.service.google;
+
+import com.example.todayserver.domain.member.entity.Member;
+import com.example.todayserver.domain.member.excpetion.code.MemberErrorCode;
+import com.example.todayserver.domain.member.repository.MemberRepository;
+import com.example.todayserver.domain.schedule.connect.dto.GoogleAuthorizeUrlRes;
+import com.example.todayserver.domain.schedule.connect.dto.GoogleTokenRes;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalAccountStatus;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalAuthType;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.repository.ExternalAccountRepository;
+import com.example.todayserver.domain.schedule.connect.service.ExternalSyncAsyncService;
+import com.example.todayserver.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleConnectService {
+
+    private final MemberRepository memberRepository;
+    private final ExternalAccountRepository externalAccountRepository;
+    private final GoogleOAuthClient googleOAuthClient;
+    private final ExternalSyncAsyncService externalSyncAsyncService;
+
+
+    // Google 캘린더 연동 인가 URL 생성
+    @Transactional(readOnly = true)
+    public GoogleAuthorizeUrlRes buildGoogleAuthorizeUrl(Long memberId) {
+        String state = String.valueOf(memberId);
+        String url = googleOAuthClient.buildAuthorizeUrl(state);
+        return new GoogleAuthorizeUrlRes(url);
+    }
+
+    // Google OAuth 콜백 처리
+    @Transactional
+    public void handleGoogleCallback(String code, Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(MemberErrorCode.NOT_FOUND));
+
+        // code -> token 교환 (서버 ↔ 구글 서버)
+        GoogleTokenRes tokenRes = googleOAuthClient.exchangeCodeForToken(code);
+        LocalDateTime expiresAt = googleOAuthClient.calcExpiresAt(tokenRes.expiresIn());
+
+        // ExternalAccount 조회 or 생성
+        ExternalAccount externalAccount = externalAccountRepository
+                .findByMemberAndProvider(member, ExternalProvider.GOOGLE)
+                .orElseGet(() -> ExternalAccount.builder()
+                        .member(member)
+                        .provider(ExternalProvider.GOOGLE)
+                        .authType(ExternalAuthType.OAUTH)
+                        .status(ExternalAccountStatus.CONNECTED)
+                        .build()
+                );
+
+        // 토큰/상태 업데이트
+        externalAccount.updateTokens(tokenRes.accessToken(), tokenRes.refreshToken(), expiresAt);
+        externalAccount.updateStatus(ExternalAccountStatus.CONNECTED);
+        externalAccount.updateLastSyncedAt(null); // 아직 동기화 전이므로 초기화
+
+        // 저장
+        externalAccountRepository.save(externalAccount);
+
+        // 일정 자동 동기화
+        LocalDate now = LocalDate.now();
+        runAfterCommit(() -> externalSyncAsyncService.syncMonth(
+                memberId,
+                ExternalProvider.GOOGLE,
+                now.getYear(),
+                now.getMonthValue()
+        ));
+    }
+
+    private void runAfterCommit(Runnable task) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    task.run();
+                }
+            });
+        } else {
+            task.run();
+        }
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/google/GoogleEventMapper.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/google/GoogleEventMapper.java
@@ -1,0 +1,38 @@
+package com.example.todayserver.domain.schedule.connect.service.google;
+
+import com.example.todayserver.domain.member.entity.Member;
+import com.example.todayserver.domain.schedule.connect.converter.ScheduleConverter;
+import com.example.todayserver.domain.schedule.connect.converter.ScheduleExternalConverter;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalSource;
+import com.example.todayserver.domain.schedule.connect.entity.ScheduleExternal;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.enums.ScheduleExternalVersionType;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalEventMapper;
+import com.example.todayserver.domain.schedule.entity.Schedule;
+import com.example.todayserver.domain.schedule.enums.ScheduleSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GoogleEventMapper implements ExternalEventMapper {
+
+    @Override
+    public ExternalProvider provider() {
+        return ExternalProvider.GOOGLE;
+    }
+
+    @Override
+    public ScheduleExternalVersionType versionType() {
+        return ScheduleExternalVersionType.ETAG;
+    }
+
+    @Override
+    public Schedule toSchedule(ExternalEventDto event, Member member) {
+        return ScheduleConverter.fromExternalEvent(event, member, ScheduleSource.GOOGLE);
+    }
+
+    @Override
+    public ScheduleExternal toScheduleExternal(ExternalEventDto event, ExternalSource source, Schedule schedule) {
+        return ScheduleExternalConverter.newMapping(event, source, schedule, versionType());
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/google/GoogleOAuthClient.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/google/GoogleOAuthClient.java
@@ -1,0 +1,82 @@
+package com.example.todayserver.domain.schedule.connect.service.google;
+
+import com.example.todayserver.domain.schedule.connect.config.GoogleOAuthProperties;
+import com.example.todayserver.domain.schedule.connect.dto.GoogleTokenRes;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalOAuthClient;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class GoogleOAuthClient implements ExternalOAuthClient {
+
+    private static final String AUTH_BASE_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+    private static final String TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+    private final GoogleOAuthProperties properties;
+    private final WebClient webClient;
+
+    public GoogleOAuthClient(
+            GoogleOAuthProperties properties,
+            @Qualifier("oauthWebClient") WebClient webClient
+    ) {
+        this.properties = properties;
+        this.webClient = webClient;
+    }
+
+    @Override
+    public String buildAuthorizeUrl(String state) {
+        URI uri = UriComponentsBuilder.fromHttpUrl(AUTH_BASE_URL)
+                .queryParam("client_id", properties.getClientId())
+                .queryParam("redirect_uri", properties.getRedirectUri())
+                .queryParam("response_type", "code")
+                .queryParam("scope", properties.getScope())
+                .queryParam("access_type", "offline")
+                .queryParam("include_granted_scopes", "true")
+                .queryParam("prompt", "consent")
+                .queryParam("state", state)
+                .build()
+                .toUri();
+
+        return uri.toString();
+    }
+
+    @Override
+    public GoogleTokenRes exchangeCodeForToken(String code) {
+        return webClient.post()
+                .uri(TOKEN_URL)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData("code", code)
+                        .with("client_id", properties.getClientId())
+                        .with("client_secret", properties.getClientSecret())
+                        .with("redirect_uri", properties.getRedirectUri())
+                        .with("grant_type", "authorization_code")
+                )
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, resp ->
+                        resp.bodyToMono(String.class)
+                                .defaultIfEmpty("")
+                                .flatMap(errorBody -> Mono.error(
+                                        new com.example.todayserver.global.common.exception.CustomException(
+                                                com.example.todayserver.global.common.exception.ErrorCode.EXTERNAL_API_ERROR
+                                        )
+                                ))
+                )
+                .bodyToMono(GoogleTokenRes.class)
+                .block();
+    }
+
+    public LocalDateTime calcExpiresAt(Long expiresInSeconds) {
+        return expiresInSeconds == null
+                ? null
+                : LocalDateTime.now().plusSeconds(expiresInSeconds);
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/entity/Schedule.java
@@ -30,7 +30,7 @@ public class Schedule extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ScheduleType scheduleType;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     @Enumerated(EnumType.STRING)
     private Mode mode;
 

--- a/src/main/java/com/example/todayserver/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/todayserver/global/common/exception/ErrorCode.java
@@ -21,7 +21,19 @@ public enum ErrorCode implements BaseErrorCode {
     SCHEDULE_EVENT_DATETIME_FORMAT_INVALID(HttpStatus.BAD_REQUEST, "SCHEDULE400_4", "startAt/endAt는 'yyyy-MM-dd HH:mm' 형식이어야 합니다."),
     SCHEDULE_REPEAT_TYPE_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE400_5", "repeatType은 필수 입력입니다."),
     SCHEDULE_DURATION_INVALID(HttpStatus.BAD_REQUEST, "SCHEDULE400_6", "duration은 1분 이상이어야 합니다."),
-    SCHEDULE_TODO_CUSTOM_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE400_7", "date는 필수 입력입니다.");
+    SCHEDULE_TODO_CUSTOM_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "SCHEDULE400_7", "date는 필수 입력입니다."),
+
+    // External
+    EXTERNAL_OAUTH_STATE_INVALID(HttpStatus.BAD_REQUEST, "EXTERNAL400_1", "외부 연동 state 값이 올바르지 않습니다."),
+    EXTERNAL_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "EXTERNAL404_1", "연결된 외부 계정을 찾을 수 없습니다."),
+    EXTERNAL_ACCOUNT_INACTIVE(HttpStatus.BAD_REQUEST, "EXTERNAL400_2", "비활성화된 외부 계정입니다."),
+    EXTERNAL_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "EXTERNAL400_3", "지원하지 않는 외부 연동 제공자입니다."),
+    EXTERNAL_CLIENT_NOT_REGISTERED(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL500_1", "외부 연동 클라이언트가 등록되지 않았습니다."),
+    EXTERNAL_MAPPER_NOT_REGISTERED(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL500_2", "외부 이벤트 매퍼가 등록되지 않았습니다."),
+    EXTERNAL_SOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXTERNAL404_2", "외부 캘린더 소스를 찾을 수 없습니다."),
+    EXTERNAL_SYNC_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL500_3", "외부 일정 동기화 중 오류가 발생했습니다."),
+    EXTERNAL_ACCESS_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "EXTERNAL400_4", "외부 연동 계정의 액세스 토큰이 존재하지 않습니다."),
+    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL500_4", "외부 캘린더 API 호출 중 오류가 발생했습니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/todayserver/global/config/AsyncConfig.java
+++ b/src/main/java/com/example/todayserver/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.example.todayserver.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/example/todayserver/global/config/WebClientConfig.java
+++ b/src/main/java/com/example/todayserver/global/config/WebClientConfig.java
@@ -1,0 +1,46 @@
+package com.example.todayserver.global.config;
+
+import io.netty.channel.ChannelOption;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+public class WebClientConfig {
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(10);
+
+    @Bean
+    public WebClient oauthWebClient() {
+        return WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient()))
+                .build();
+    }
+
+    @Bean
+    public WebClient googleCalendarWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://www.googleapis.com/calendar/v3")
+                .clientConnector(new ReactorClientHttpConnector(httpClient()))
+                .build();
+    }
+
+    private HttpClient httpClient() {
+        return HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) CONNECT_TIMEOUT.toMillis())
+                .responseTimeout(RESPONSE_TIMEOUT)
+                .doOnConnected(conn -> conn
+                        .addHandlerLast(new ReadTimeoutHandler((int) RESPONSE_TIMEOUT.toSeconds(), TimeUnit.SECONDS))
+                        .addHandlerLast(new WriteTimeoutHandler((int) RESPONSE_TIMEOUT.toSeconds(), TimeUnit.SECONDS))
+                );
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,3 +65,11 @@ jwt:
     secretKey: ${SECRET_KEY}
     expiration:
       access: 3600000
+
+google:
+  oauth2:
+    calendar:
+      client-id: ${GOOGLE_CLIENT_ID}
+      client-secret: ${GOOGLE_CLIENT_SECRET}
+      redirect-uri: ${GOOGLE_REDIRECT_URI}
+      scope: https://www.googleapis.com/auth/calendar.readonly


### PR DESCRIPTION
## 관련 이슈
#40 
<br>

## 작업 내용
- 외부 캘린더 연동 관련 엔티티 구현 (ExternalAccount, ExternalSource, ScheduleExternal)
- 외부 캘린더 연동 인터페이스 구현
- 구글 캘린더 연동 API 구현 
  - Google 캘린더 연동 인가 URL 발급 API 
  - Google 캘린더 연동 콜백 처리 API (콜백 완료시 비동기로 일정 조회 및 DB 저장)
<br> 

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
