### PR TITLE
[Feat] Notion 캘린더 연동 API 구현

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -59,4 +59,9 @@ jobs:
               -e GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}" \
               -e NAVER_CLIENT_ID="${{ secrets.NAVER_CLIENT_ID }}" \
               -e NAVER_CLIENT_SECRET="${{ secrets.NAVER_CLIENT_SECRET }}" \
+              -e GOOGLE_REDIRECT_URI="${{ secrets.GOOGLE_REDIRECT_URI }}" \
+              -e NOTION_CLIENT_ID="${{ secrets.NOTION_CLIENT_ID }}" \
+              -e NOTION_CLIENT_SECRET="${{ secrets.NOTION_CLIENT_SECRET }}" \
+              -e NOTION_REDIRECT_URI="${{ secrets.NOTION_REDIRECT_URI }}" \
+              -e NOTION_VERSION="${{ secrets.NOTION_VERSION }}" \
               ${{ secrets.DOCKERHUB_USERNAME }}/today-app

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/config/NotionOAuthProperties.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/config/NotionOAuthProperties.java
@@ -1,0 +1,18 @@
+package com.example.todayserver.domain.schedule.connect.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "external.notion")
+public class NotionOAuthProperties {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String version;
+    private String apiBase;
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalIntegrationController.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalIntegrationController.java
@@ -1,7 +1,9 @@
 package com.example.todayserver.domain.schedule.connect.controller;
 
 import com.example.todayserver.domain.schedule.connect.dto.GoogleAuthorizeUrlRes;
+import com.example.todayserver.domain.schedule.connect.dto.NotionAuthorizeUrlRes;
 import com.example.todayserver.domain.schedule.connect.service.google.GoogleConnectService;
+import com.example.todayserver.domain.schedule.connect.service.notion.NotionConnectService;
 import com.example.todayserver.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class ExternalIntegrationController {
 
     private final GoogleConnectService googleConnectService;
+    private final NotionConnectService notionConnectService;
 
     @Operation(
             summary = "Google 캘린더 연동 인가 URL 발급",
@@ -45,6 +48,37 @@ public class ExternalIntegrationController {
             @AuthenticationPrincipal(expression = "id") Long memberId
     ) {
         googleConnectService.handleGoogleCallback(code, memberId);
+        return ApiResponse.success(null);
+    }
+
+    @Operation(
+            summary = "Notion 연동 인가 URL 발급",
+            description = "현재 로그인한 사용자의 Notion 연동을 위한 OAuth 인가 URL을 생성합니다. "
+    )
+    @PostMapping("/notion/authorize")
+    public ApiResponse<NotionAuthorizeUrlRes> authorizeNotion(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "id") Long memberId
+    ) {
+        String authorizeUrl = notionConnectService.buildAuthorizeUrl(memberId);
+        return ApiResponse.success(new NotionAuthorizeUrlRes(authorizeUrl));
+    }
+
+    @Operation(
+            summary = "Notion 연동 콜백 처리",
+            description = "Notion OAuth 콜백을 받아 Authorization Code를 토큰으로 교환하고 ExternalAccount에 저장합니다."
+    )
+    @GetMapping("/notion/callback")
+    public ApiResponse<Void> callbackNotion(
+            @RequestParam("code")
+            @Parameter(description = "Notion OAuth Authorization Code", example = "abc123...")
+            String code,
+
+            @RequestParam("state")
+            @Parameter(description = "서버가 인가 URL 생성 시 발급한 state", example = "st_550e8400-e29b-41d4-a716-446655440000")
+            String state
+    ) {
+        notionConnectService.handleCallback(code, state);
         return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/dto/NotionAuthorizeUrlRes.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/dto/NotionAuthorizeUrlRes.java
@@ -1,0 +1,13 @@
+package com.example.todayserver.domain.schedule.connect.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Notion 캘린더 연동 인가 URL 응답")
+public record NotionAuthorizeUrlRes(
+        @Schema(
+                description = "프론트에서 이동할 Notion OAuth 인가 URL",
+                example = "https://accounts.google.com/o/oauth2/v2/auth?client_id=..."
+        )
+                String authorizeUrl
+) {
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/dto/NotionCalendarDto.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/dto/NotionCalendarDto.java
@@ -1,0 +1,57 @@
+package com.example.todayserver.domain.schedule.connect.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public final class NotionCalendarDto {
+
+    private NotionCalendarDto() {}
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record SearchRequest(Filter filter, Integer page_size, String query, Sort sort) {
+
+        public static SearchRequest dataSourcesOnly(int pageSize) {
+            return new SearchRequest(new Filter("object", "data_source"), pageSize, null, null);
+        }
+
+        public record Filter(String property, String value) {}
+        public record Sort(String direction, String timestamp) {}
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record DatabaseQueryRequest(Object filter, List<Object> sorts, Integer page_size, String start_cursor) {
+        public static DatabaseQueryRequest empty() {
+            return new DatabaseQueryRequest(null, null, null, null);
+        }
+    }
+
+    public record Mapping(String titleProp, String dateProp) {
+
+        public static Mapping fromMetaJson(String metaJson, ObjectMapper om) {
+            String title = "Name";
+            String date = "Date";
+
+            if (metaJson == null || metaJson.isBlank()) return new Mapping(title, date);
+
+            try {
+                JsonNode n = om.readTree(metaJson);
+                String t = n.path("titleProp").asText(null);
+                String d = n.path("dateProp").asText(null);
+
+                if (t != null && !t.isBlank()) title = t;
+                if (d != null && !d.isBlank()) date = d;
+
+            } catch (Exception ignored) {
+                // metaJson 파싱 실패해도 기본값으로 동작
+            }
+
+            return new Mapping(title, date);
+        }
+    }
+
+    public record DateRange(LocalDateTime start, LocalDateTime end, boolean allDay) {}
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/dto/NotionTokenRes.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/dto/NotionTokenRes.java
@@ -1,0 +1,12 @@
+package com.example.todayserver.domain.schedule.connect.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record NotionTokenRes(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("workspace_id") String workspaceId,
+        @JsonProperty("workspace_name") String workspaceName,
+        @JsonProperty("bot_id") String botId,
+        @JsonProperty("owner") Object owner
+) {}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ExternalAccountRepository.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ExternalAccountRepository.java
@@ -16,4 +16,8 @@ public interface ExternalAccountRepository extends JpaRepository<ExternalAccount
             Long memberId, ExternalProvider provider, ExternalAccountStatus status
     );
 
+    Optional<ExternalAccount> findByMemberIdAndProvider(Long memberId, ExternalProvider provider);
+
+    Optional<ExternalAccount> findByProviderAndOauthState(ExternalProvider provider, String oauthState);
+
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/notion/NotionCalendarClient.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/notion/NotionCalendarClient.java
@@ -1,0 +1,111 @@
+package com.example.todayserver.domain.schedule.connect.service.notion;
+
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalSourceDto;
+import com.example.todayserver.domain.schedule.connect.dto.NotionCalendarDto;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalSource;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalCalendarClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotionCalendarClient implements ExternalCalendarClient {
+
+    private static final String SEARCH_URI = "/search";
+    private static final String QUERY_URI = "/data_sources/{id}/query";
+    private static final int SEARCH_PAGE_SIZE = 50;
+
+    @Qualifier("notionWebClient")
+    private final WebClient notionWebClient;
+
+    private final NotionEventParser notionEventParser;
+
+    @Override
+    public ExternalProvider provider() {
+        return ExternalProvider.NOTION;
+    }
+
+    // Notion Search API를 호출하여 사용자가 접근 가능한 데이터소스(Database) 목록을 조회
+    @Override
+    public List<ExternalSourceDto> fetchSources(ExternalAccount account) {
+        Long memberId = account.getMember().getId();
+
+        try {
+            JsonNode res = notionWebClient.post()
+                    .uri(SEARCH_URI)
+                    .header(HttpHeaders.AUTHORIZATION, bearer(account.getAccessToken()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(NotionCalendarDto.SearchRequest.dataSourcesOnly(SEARCH_PAGE_SIZE))
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            List<ExternalSourceDto> out = notionEventParser.parseSources(res);
+
+            log.info("[Notion][FETCH_SOURCES][SUCCESS] memberId={}, sources={}", memberId, out.size());
+            return out;
+
+        } catch (WebClientResponseException e) {
+            log.error("[Notion][FETCH_SOURCES][FAIL] memberId={}, status={}, body={}",
+                    memberId, e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new IllegalStateException("Notion /search 실패: " + e.getResponseBodyAsString(), e);
+
+        } catch (Exception e) {
+            log.error("[Notion][FETCH_SOURCES][FAIL] memberId={}, unexpectedError={}",
+                    memberId, e.toString(), e);
+            throw e;
+        }
+    }
+
+    // Notion Database Query API를 호출하여 특정 데이터소스(ExternalSource)의 페이지들을 조회
+    @Override
+    public List<ExternalEventDto> fetchEvents(ExternalAccount account, ExternalSource source, LocalDateTime from, LocalDateTime to) {
+        Long memberId = account.getMember().getId();
+        String sourceId = source.getSourceKey();
+
+        try {
+            JsonNode res = notionWebClient.post()
+                    .uri(uriBuilder -> uriBuilder.path(QUERY_URI).build(sourceId))
+                    .header(HttpHeaders.AUTHORIZATION, bearer(account.getAccessToken()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(NotionCalendarDto.DatabaseQueryRequest.empty())
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            List<ExternalEventDto> out = notionEventParser.parseEvents(res, source.getMetaJson(), from, to);
+
+            log.info("[Notion][FETCH_EVENTS][SUCCESS] memberId={}, sourceId={}, events={}, range={}~{}",
+                    memberId, sourceId, out.size(), from, to);
+            return out;
+
+        } catch (WebClientResponseException e) {
+            log.error("[Notion][FETCH_EVENTS][FAIL] memberId={}, sourceId={}, status={}, body={}",
+                    memberId, sourceId, e.getStatusCode(), e.getResponseBodyAsString(), e);
+            throw new IllegalStateException("Notion database query 실패: body=" + e.getResponseBodyAsString(), e);
+
+        } catch (Exception e) {
+            log.error("[Notion][FETCH_EVENTS][FAIL] memberId={}, sourceId={}, unexpectedError={}",
+                    memberId, sourceId, e.toString(), e);
+            throw e;
+        }
+    }
+
+    private String bearer(String token) {
+        return "Bearer " + token;
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/notion/NotionConnectService.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/notion/NotionConnectService.java
@@ -1,0 +1,77 @@
+package com.example.todayserver.domain.schedule.connect.service.notion;
+
+import com.example.todayserver.domain.member.repository.MemberRepository;
+import com.example.todayserver.domain.schedule.connect.dto.NotionTokenRes;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalAccountStatus;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalAuthType;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.repository.ExternalAccountRepository;
+import com.example.todayserver.domain.schedule.connect.service.ExternalSyncAsyncService;
+import com.example.todayserver.global.common.exception.CustomException;
+import com.example.todayserver.global.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class NotionConnectService {
+
+    private final ExternalAccountRepository externalAccountRepository;
+    private final MemberRepository memberRepository;
+    private final NotionOAuthClient notionOAuthClient;
+    private final ExternalSyncAsyncService externalSyncAsyncService;
+
+    @Transactional
+    public String buildAuthorizeUrl(Long memberId) {
+
+        ExternalAccount account = externalAccountRepository
+                .findByMemberIdAndProvider(memberId, ExternalProvider.NOTION)
+                .orElseGet(() ->
+                        externalAccountRepository.save(
+                                ExternalAccount.builder()
+                                        .member(memberRepository.getReferenceById(memberId))
+                                        .provider(ExternalProvider.NOTION)
+                                        .authType(ExternalAuthType.OAUTH)
+                                        .status(ExternalAccountStatus.ERROR)
+                                        .build()
+                        )
+                );
+
+        String state = "st_" + UUID.randomUUID();
+        account.issueOAuthState(state, LocalDateTime.now().plusMinutes(10));
+
+        return notionOAuthClient.buildAuthorizeUrl(state);
+    }
+
+    @Transactional
+    public void handleCallback(String code, String state) {
+
+        ExternalAccount account = externalAccountRepository
+                .findByProviderAndOauthState(ExternalProvider.NOTION, state)
+                .orElseThrow(() -> new CustomException(ErrorCode.EXTERNAL_OAUTH_STATE_INVALID));
+
+        if (account.isOAuthStateExpired()) {
+            throw new CustomException(ErrorCode.EXTERNAL_OAUTH_STATE_INVALID);
+        }
+
+        NotionTokenRes token = notionOAuthClient.exchangeCodeForToken(code);
+
+        // Notion은 일반적으로 refresh token / expires_at을 주지 않는 형태라 null 처리
+        account.activate(token.accessToken(), null);
+
+        // 일정 자동 동기화
+        LocalDate now = LocalDate.now();
+        externalSyncAsyncService.syncMonth(
+                account.getMember().getId(),
+                ExternalProvider.NOTION,
+                now.getYear(),
+                now.getMonthValue()
+        );
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/notion/NotionEventMapper.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/notion/NotionEventMapper.java
@@ -1,0 +1,47 @@
+package com.example.todayserver.domain.schedule.connect.service.notion;
+
+import com.example.todayserver.domain.member.entity.Member;
+import com.example.todayserver.domain.schedule.connect.converter.ScheduleConverter;
+import com.example.todayserver.domain.schedule.connect.converter.ScheduleExternalConverter;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalSource;
+import com.example.todayserver.domain.schedule.connect.entity.ScheduleExternal;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.enums.ScheduleExternalVersionType;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalEventMapper;
+import com.example.todayserver.domain.schedule.entity.Schedule;
+import com.example.todayserver.domain.schedule.enums.ScheduleSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotionEventMapper implements ExternalEventMapper {
+
+    @Override
+    public ExternalProvider provider() {
+        return ExternalProvider.NOTION;
+    }
+
+    @Override
+    public ScheduleExternalVersionType versionType() {
+        return ScheduleExternalVersionType.UPDATED_AT;
+    }
+
+    @Override
+    public Schedule toSchedule(ExternalEventDto event, Member member) {
+        return ScheduleConverter.fromExternalEvent(
+                event,
+                member,
+                ScheduleSource.NOTION
+        );
+    }
+
+    @Override
+    public ScheduleExternal toScheduleExternal(ExternalEventDto event, ExternalSource source, Schedule schedule) {
+        return ScheduleExternalConverter.newMapping(
+                event,
+                source,
+                schedule,
+                versionType()
+        );
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/notion/NotionEventParser.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/notion/NotionEventParser.java
@@ -1,0 +1,166 @@
+package com.example.todayserver.domain.schedule.connect.service.notion;
+
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalSourceDto;
+import com.example.todayserver.domain.schedule.connect.dto.NotionCalendarDto;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+// Notion API 응답(Json)을 내부 DTO로 변환하는 파서
+@Component
+@RequiredArgsConstructor
+public class NotionEventParser {
+
+    // Notion DB 기본 템플릿 기준 매핑 (초기 연동 시 사용)
+    private static final String DEFAULT_META_JSON = "{\"titleProp\":\"이름\",\"dateProp\":\"날짜\"}";
+
+    private final ObjectMapper objectMapper;
+
+    // Notion search API 결과에서 연동 가능한 데이터 소스(Database) 목록을 추출
+    public List<ExternalSourceDto> parseSources(JsonNode res) {
+        if (!hasResultsArray(res)) return List.of();
+
+        List<ExternalSourceDto> out = new ArrayList<>();
+        for (JsonNode item : res.get("results")) {
+            String object = item.path("object").asText();
+            if (!"data_source".equals(object) && !"database".equals(object)) continue;
+
+            String id = item.path("id").asText();
+            String title = extractRichTextTitle(item.path("title")).orElse("(Untitled)");
+
+            out.add(new ExternalSourceDto(id, title, DEFAULT_META_JSON));
+        }
+        return out;
+    }
+
+    // Notion database query 결과에서 일정(Page)을 ExternalEventDto 목록으로 변환한다.
+    public List<ExternalEventDto> parseEvents(
+            JsonNode res,
+            String metaJson,
+            LocalDateTime from,
+            LocalDateTime to
+    ) {
+        if (!hasResultsArray(res)) return List.of();
+
+        NotionCalendarDto.Mapping mapping =
+                NotionCalendarDto.Mapping.fromMetaJson(metaJson, objectMapper);
+
+        List<ExternalEventDto> out = new ArrayList<>();
+        for (JsonNode page : res.get("results")) {
+            if (!"page".equals(page.path("object").asText())) continue;
+
+            JsonNode props = page.path("properties");
+
+            String title = extractTitleFromProperties(props, mapping.titleProp())
+                    .orElse("(제목 없음)");
+
+            Optional<NotionCalendarDto.DateRange> drOpt =
+                    extractDateRangeFromProperties(props, mapping.dateProp());
+            if (drOpt.isEmpty() || drOpt.get().start() == null) continue;
+
+            NotionCalendarDto.DateRange dr = drOpt.get();
+            LocalDateTime start = dr.start();
+            LocalDateTime end = (dr.end() != null) ? dr.end() : dr.start();
+
+            // 요청한 월 범위 밖 이벤트 제외
+            if (!isInRange(start, end, from, to)) continue;
+
+            String pageId = page.path("id").asText();
+            String lastEdited = page.path("last_edited_time").asText(null);
+
+            out.add(new ExternalEventDto(
+                    pageId,
+                    title,
+                    null,
+                    start,
+                    end,
+                    dr.allDay(),
+                    parseNotionDateTime(lastEdited),
+                    lastEdited,
+                    page.toString()
+            ));
+        }
+
+        return out;
+    }
+
+     // Notion 응답에 results 배열이 존재하는지 확인
+    private boolean hasResultsArray(JsonNode res) {
+        return res != null && res.has("results") && res.get("results").isArray();
+    }
+
+     // 이벤트가 요청한 기간(from~to)에 포함되는지 판단
+    private boolean isInRange(LocalDateTime start, LocalDateTime end, LocalDateTime from, LocalDateTime to) {
+        return !(start.isAfter(to) || end.isBefore(from));
+    }
+
+     // Notion title 배열에서 첫 번째 plain_text 값을 추출
+    private Optional<String> extractRichTextTitle(JsonNode titleArray) {
+        if (titleArray == null || !titleArray.isArray() || titleArray.isEmpty()) return Optional.empty();
+        return Optional.ofNullable(titleArray.get(0).path("plain_text").asText(null));
+    }
+
+
+     // properties에서 title 타입 속성 값을 추출
+    private Optional<String> extractTitleFromProperties(JsonNode props, String titlePropName) {
+        if (props == null || titlePropName == null) return Optional.empty();
+
+        JsonNode p = props.path(titlePropName);
+        if (p.isMissingNode() || p.isNull()) return Optional.empty();
+
+        JsonNode titleArr = p.path("title");
+        if (!titleArr.isArray() || titleArr.isEmpty()) return Optional.empty();
+
+        return Optional.ofNullable(titleArr.get(0).path("plain_text").asText(null));
+    }
+
+     // properties에서 date 타입 속성을 추출해 DateRange로 변환
+     private Optional<NotionCalendarDto.DateRange> extractDateRangeFromProperties(
+            JsonNode props,
+            String datePropName
+    ) {
+        if (props == null || datePropName == null) return Optional.empty();
+
+        JsonNode p = props.path(datePropName);
+        if (p.isMissingNode() || p.isNull()) return Optional.empty();
+
+        JsonNode date = p.path("date");
+        if (date.isMissingNode() || date.isNull()) return Optional.empty();
+
+        String startStr = date.path("start").asText(null);
+        String endStr = date.path("end").asText(null);
+
+        LocalDateTime start = parseNotionDateTime(startStr);
+        LocalDateTime end = parseNotionDateTime(endStr);
+
+        boolean allDay = isAllDayFormat(startStr, endStr);
+        return Optional.of(new NotionCalendarDto.DateRange(start, end, allDay));
+    }
+
+    // 날짜 문자열이 YYYY-MM-DD 형식인지 판단하여 종일 일정 여부를 계산
+    private boolean isAllDayFormat(String startStr, String endStr) {
+        return (startStr != null && startStr.length() == 10)
+                && (endStr == null || endStr.length() == 10);
+    }
+
+    // Notion 날짜 문자열을 LocalDateTime으로 변환
+    private LocalDateTime parseNotionDateTime(String iso) {
+        if (iso == null || iso.isBlank()) return null;
+
+        if (iso.length() == 10) {
+            LocalDate d = LocalDate.parse(iso);
+            return d.atStartOfDay();
+        }
+
+        return OffsetDateTime.parse(iso).toLocalDateTime();
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/notion/NotionOAuthClient.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/notion/NotionOAuthClient.java
@@ -1,0 +1,68 @@
+package com.example.todayserver.domain.schedule.connect.service.notion;
+
+import com.example.todayserver.domain.schedule.connect.config.NotionOAuthProperties;
+import com.example.todayserver.domain.schedule.connect.dto.NotionTokenRes;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalOAuthClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import java.util.Base64;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class NotionOAuthClient implements ExternalOAuthClient {
+
+    private final NotionOAuthProperties props;
+
+    @Qualifier("notionWebClient")
+    private final WebClient notionWebClient;
+
+    /**
+     * Notion OAuth 인가 URL 생성
+     * https://api.notion.com/v1/oauth/authorize
+     */
+    @Override
+    public String buildAuthorizeUrl(String state) {
+        return UriComponentsBuilder
+                .fromHttpUrl("https://api.notion.com/v1/oauth/authorize")
+                .queryParam("client_id", props.getClientId())
+                .queryParam("response_type", "code")
+                .queryParam("owner", "user")
+                .queryParam("redirect_uri", props.getRedirectUri())
+                .queryParam("state", state)
+                .build(true)
+                .toUriString();
+    }
+
+    /**
+     * authorization code → access token 교환
+     * POST https://api.notion.com/v1/oauth/token
+     */
+    @Override
+    public NotionTokenRes exchangeCodeForToken(String code) {
+        String basicAuth = Base64.getEncoder().encodeToString(
+                (props.getClientId() + ":" + props.getClientSecret())
+                        .getBytes(StandardCharsets.UTF_8)
+        );
+
+        return notionWebClient.post()
+                .uri("/oauth/token")
+                .header(HttpHeaders.AUTHORIZATION, "Basic " + basicAuth)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(Map.of(
+                        "grant_type", "authorization_code",
+                        "code", code,
+                        "redirect_uri", props.getRedirectUri()
+                ))
+                .retrieve()
+                .bodyToMono(NotionTokenRes.class)
+                .block();
+    }
+}

--- a/src/main/java/com/example/todayserver/global/config/WebClientConfig.java
+++ b/src/main/java/com/example/todayserver/global/config/WebClientConfig.java
@@ -1,12 +1,13 @@
 package com.example.todayserver.global.config;
 
+import com.example.todayserver.domain.schedule.connect.config.NotionOAuthProperties;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
-import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 
@@ -14,10 +15,13 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebClientConfig {
 
     private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(3);
     private static final Duration RESPONSE_TIMEOUT = Duration.ofSeconds(10);
+
+    private final NotionOAuthProperties notionProperties;
 
     @Bean
     public WebClient oauthWebClient() {
@@ -31,6 +35,18 @@ public class WebClientConfig {
         return WebClient.builder()
                 .baseUrl("https://www.googleapis.com/calendar/v3")
                 .clientConnector(new ReactorClientHttpConnector(httpClient()))
+                .build();
+    }
+
+    /**
+     * Notion API 전용 WebClient
+     * - baseUrl: https://api.notion.com/v1
+     */
+    @Bean
+    public WebClient notionWebClient() {
+        return WebClient.builder()
+                .baseUrl(notionProperties.getApiBase())
+                .defaultHeader("Notion-Version", notionProperties.getVersion())
                 .build();
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -73,3 +73,11 @@ google:
       client-secret: ${GOOGLE_CLIENT_SECRET}
       redirect-uri: ${GOOGLE_REDIRECT_URI}
       scope: https://www.googleapis.com/auth/calendar.readonly
+
+external:
+  notion:
+    client-id: ${NOTION_CLIENT_ID}
+    client-secret: ${NOTION_CLIENT_SECRET}
+    redirect-uri: ${NOTION_REDIRECT_URI}
+    version: ${NOTION_VERSION}
+    api-base: https://api.notion.com/v1


### PR DESCRIPTION
## 관련 이슈
#40 
<br>

## 작업 내용
- Notion Ouath 인증, 콜백 API 구현
  - 콜백 완료시 해당 일 +-3개월치 일정 자동 동기화
- Notion 캘린더 불러오는 로직 구현
- workflow에 노션 키 반영
<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
