### PR TITLE
[Feat] 외부 연동 상태 조회, 해지 API 구현

### DIFF
--- a/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalIntegrationController.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalIntegrationController.java
@@ -1,6 +1,7 @@
 package com.example.todayserver.domain.schedule.connect.controller;
 
 import com.example.todayserver.domain.schedule.connect.dto.GoogleAuthorizeUrlRes;
+import com.example.todayserver.domain.schedule.connect.dto.IntegrationStatusUpdateReq;
 import com.example.todayserver.domain.schedule.connect.dto.IntergrationStatueRes;
 import com.example.todayserver.domain.schedule.connect.dto.NotionAuthorizeUrlRes;
 import com.example.todayserver.domain.schedule.connect.service.ExternalIntergrationService;
@@ -35,6 +36,20 @@ public class ExternalIntegrationController {
     ) {
         IntergrationStatueRes res = externalIntergrationService.getIntegrationStatus(memberId);
         return ApiResponse.success(res);
+    }
+
+    @Operation(
+            summary = "외부 연동 해제",
+            description = "사용자가 연동 해제를 요청하면 DISCONNECTED로 변경하고 토큰 정보를 제거합니다."
+    )
+    @PatchMapping("/status")
+    public ApiResponse<Void> updateIntegrationStatus(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "id") Long memberId,
+            @RequestBody IntegrationStatusUpdateReq req
+    ) {
+        externalIntergrationService.disconnect(memberId, req);
+        return ApiResponse.success(null);
     }
 
     @Operation(

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalIntegrationController.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalIntegrationController.java
@@ -1,7 +1,9 @@
 package com.example.todayserver.domain.schedule.connect.controller;
 
 import com.example.todayserver.domain.schedule.connect.dto.GoogleAuthorizeUrlRes;
+import com.example.todayserver.domain.schedule.connect.dto.IntergrationStatueRes;
 import com.example.todayserver.domain.schedule.connect.dto.NotionAuthorizeUrlRes;
+import com.example.todayserver.domain.schedule.connect.service.ExternalIntergrationService;
 import com.example.todayserver.domain.schedule.connect.service.google.GoogleConnectService;
 import com.example.todayserver.domain.schedule.connect.service.notion.NotionConnectService;
 import com.example.todayserver.global.common.response.ApiResponse;
@@ -20,6 +22,20 @@ public class ExternalIntegrationController {
 
     private final GoogleConnectService googleConnectService;
     private final NotionConnectService notionConnectService;
+    private final ExternalIntergrationService externalIntergrationService;
+
+    @Operation(
+            summary = "외부 연동 상태 조회",
+            description = "현재 로그인한 사용자의 외부 서비스(Google/Notion/iCloud 등) 연동 여부를 조회합니다."
+    )
+    @GetMapping("/status")
+    public ApiResponse<IntergrationStatueRes> getIntegrationStatus(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal(expression = "id") Long memberId
+    ) {
+        IntergrationStatueRes res = externalIntergrationService.getIntegrationStatus(memberId);
+        return ApiResponse.success(res);
+    }
 
     @Operation(
             summary = "Google 캘린더 연동 인가 URL 발급",

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalSyncDevController.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalSyncDevController.java
@@ -1,0 +1,200 @@
+package com.example.todayserver.domain.schedule.connect.controller;
+
+import com.example.todayserver.domain.schedule.connect.dto.NotionCalendarDto;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.repository.ExternalAccountRepository;
+import com.example.todayserver.domain.schedule.connect.service.ExternalSyncAsyncService;
+import com.example.todayserver.domain.schedule.connect.service.notion.NotionCalendarClient;
+import com.example.todayserver.global.common.response.ApiResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.time.LocalDate;
+
+@Slf4j
+@Tag(name = "Dev", description = "임시 테스트용 API (배포 전 제거)")
+@RestController
+@RequestMapping("/api/v1/dev/external")
+@RequiredArgsConstructor
+public class ExternalSyncDevController {
+
+    private final ExternalSyncAsyncService externalSyncAsyncService;
+
+    @Qualifier("notionWebClient")
+    private final WebClient notionWebClient;
+
+    private final ExternalAccountRepository externalAccountRepository;
+
+    /* =========================
+       Notion - Raw API Tests
+     ========================= */
+
+    @Operation(
+            summary = "[DEV] Notion Search(data_source) 원문 호출",
+            description = "현재 로그인 사용자의 NOTION ExternalAccount 토큰으로 /v1/search를 호출하고 원문 JSON을 반환합니다."
+    )
+    @PostMapping("/notion/search/data-source")
+    public ApiResponse<JsonNode> searchNotionDataSource(
+            @AuthenticationPrincipal(expression = "id") Long memberId,
+            @RequestParam(defaultValue = "50") int pageSize
+    ) {
+        ExternalAccount account = externalAccountRepository
+                .findByMemberIdAndProvider(memberId, ExternalProvider.NOTION)
+                .orElseThrow(() -> new IllegalArgumentException("NOTION ExternalAccount 없음"));
+
+        try {
+            JsonNode res = notionWebClient.post()
+                    .uri("/search")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + account.getAccessToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    // ✅ NotionCalendarClient(정리본) 기준 SearchRequest 사용
+                    .bodyValue(NotionCalendarDto.SearchRequest.dataSourcesOnly(pageSize))
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            return ApiResponse.success(res);
+
+        } catch (WebClientResponseException e) {
+            // Notion이 내려주는 에러 바디를 그대로 확인 가능하도록
+            String body = e.getResponseBodyAsString();
+            log.error("[DevNotion][FAIL] /search status={}, body={}", e.getStatusCode(), body);
+            throw new IllegalStateException("Notion /search 실패: status=" + e.getStatusCode() + ", body=" + body, e);
+        }
+    }
+
+    @Operation(
+            summary = "[DEV] Notion Database Query 원문 호출",
+            description = "databaseId를 받아 /v1/databases/{id}/query를 호출하고 원문 JSON을 반환합니다."
+    )
+    @PostMapping("/notion/database/{databaseId}/query")
+    public ApiResponse<JsonNode> queryNotionDatabaseRaw(
+            @AuthenticationPrincipal(expression = "id") Long memberId,
+            @PathVariable String databaseId
+    ) {
+        ExternalAccount account = externalAccountRepository
+                .findByMemberIdAndProvider(memberId, ExternalProvider.NOTION)
+                .orElseThrow(() -> new IllegalArgumentException("NOTION ExternalAccount 없음"));
+
+        try {
+            JsonNode res = notionWebClient.post()
+                    .uri(uriBuilder -> uriBuilder.path("/databases/{id}/query").build(databaseId))
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + account.getAccessToken())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(NotionCalendarDto.DatabaseQueryRequest.empty())
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block();
+
+            return ApiResponse.success(res);
+
+        } catch (WebClientResponseException e) {
+            String body = e.getResponseBodyAsString();
+            log.error("[DevNotion][FAIL] /databases/{}/query status={}, body={}", databaseId, e.getStatusCode(), body);
+            throw new IllegalStateException("Notion DB query 실패: status=" + e.getStatusCode() + ", body=" + body, e);
+        }
+    }
+
+    /* =========================
+       Notion - Sync Tests
+     ========================= */
+
+    @Operation(
+            summary = "[DEV] Notion 월 동기화 강제 실행(로그인 사용자)",
+            description = "현재 로그인한 사용자(memberId) 기준으로 Notion 동기화를 비동기 실행합니다. (임시 테스트용)"
+    )
+    @PostMapping("/notion/sync/month")
+    public ApiResponse<String> syncNotionMonthForLoginUser(
+            @AuthenticationPrincipal(expression = "id") Long memberId,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month
+    ) {
+        LocalDate now = LocalDate.now();
+        int y = (year == null) ? now.getYear() : year;
+        int m = (month == null) ? now.getMonthValue() : month;
+
+        log.info("[DevSync] request syncMonth memberId={}, provider=NOTION, year={}, month={}", memberId, y, m);
+
+        externalSyncAsyncService.syncMonth(memberId, ExternalProvider.NOTION, y, m);
+
+        return ApiResponse.success("sync requested");
+    }
+
+    @Operation(
+            summary = "[DEV] Notion 월 동기화 강제 실행(memberId 직접 입력)",
+            description = "memberId를 파라미터로 받아 Notion 동기화를 비동기 실행합니다. (임시 테스트용)"
+    )
+    @PostMapping("/notion/sync/month/{memberId}")
+    public ApiResponse<String> syncNotionMonthForMemberId(
+            @PathVariable Long memberId,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month
+    ) {
+        LocalDate now = LocalDate.now();
+        int y = (year == null) ? now.getYear() : year;
+        int m = (month == null) ? now.getMonthValue() : month;
+
+        log.info("[DevSync] request syncMonth memberId={}, provider=NOTION, year={}, month={}", memberId, y, m);
+
+        externalSyncAsyncService.syncMonth(memberId, ExternalProvider.NOTION, y, m);
+
+        return ApiResponse.success("sync requested");
+    }
+
+    /* =========================
+       Google - Existing Sync Tests
+     ========================= */
+
+    @Operation(
+            summary = "[DEV] 구글 캘린더 월 동기화 강제 실행(로그인 사용자)",
+            description = "현재 로그인한 사용자(memberId) 기준으로 Google 동기화를 비동기 실행합니다. (임시 테스트용)"
+    )
+    @PostMapping("/google/sync/month")
+    public ApiResponse<String> syncGoogleMonthForLoginUser(
+            @AuthenticationPrincipal(expression = "id") Long memberId,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month
+    ) {
+        LocalDate now = LocalDate.now();
+        int y = (year == null) ? now.getYear() : year;
+        int m = (month == null) ? now.getMonthValue() : month;
+
+        log.info("[DevSync] request syncMonth memberId={}, provider=GOOGLE, year={}, month={}", memberId, y, m);
+
+        externalSyncAsyncService.syncMonth(memberId, ExternalProvider.GOOGLE, y, m);
+
+        return ApiResponse.success("sync requested");
+    }
+
+    @Operation(
+            summary = "[DEV] 구글 캘린더 월 동기화 강제 실행(memberId 직접 입력)",
+            description = "memberId를 파라미터로 받아 Google 동기화를 비동기 실행합니다. (임시 테스트용)"
+    )
+    @PostMapping("/google/sync/month/{memberId}")
+    public ApiResponse<String> syncGoogleMonthForMemberId(
+            @PathVariable Long memberId,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month
+    ) {
+        LocalDate now = LocalDate.now();
+        int y = (year == null) ? now.getYear() : year;
+        int m = (month == null) ? now.getMonthValue() : month;
+
+        log.info("[DevSync] request syncMonth memberId={}, provider=GOOGLE, year={}, month={}", memberId, y, m);
+
+        externalSyncAsyncService.syncMonth(memberId, ExternalProvider.GOOGLE, y, m);
+
+        return ApiResponse.success("sync requested");
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/converter/ExternalIntegrationConverter.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/converter/ExternalIntegrationConverter.java
@@ -1,0 +1,21 @@
+package com.example.todayserver.domain.schedule.connect.converter;
+
+import com.example.todayserver.domain.schedule.connect.dto.IntergrationStatueRes;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+@Component
+public class ExternalIntegrationConverter {
+
+    public IntergrationStatueRes toStatusRes(Set<ExternalProvider> connectedProviders) {
+        List<IntergrationStatueRes.ProviderStatus> providers = EnumSet.allOf(ExternalProvider.class).stream()
+                .map(p -> new IntergrationStatueRes.ProviderStatus(p, connectedProviders.contains(p)))
+                .toList();
+
+        return new IntergrationStatueRes(providers);
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/dto/IntegrationStatusUpdateReq.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/dto/IntegrationStatusUpdateReq.java
@@ -1,0 +1,13 @@
+package com.example.todayserver.domain.schedule.connect.dto;
+
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record IntegrationStatusUpdateReq(
+        @Schema(description = "외부 제공자", example = "GOOGLE")
+        ExternalProvider provider,
+
+        @Schema(description = "연동 여부 (false면 해제 처리)", example = "false")
+        boolean connected
+) {
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/dto/IntergrationStatueRes.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/dto/IntergrationStatueRes.java
@@ -1,0 +1,16 @@
+package com.example.todayserver.domain.schedule.connect.dto;
+
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+
+import java.util.List;
+
+public record IntergrationStatueRes(
+        List<ProviderStatus> providers
+) {
+
+    public record ProviderStatus(
+            ExternalProvider provider,
+            boolean connected
+    ) {
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/entity/ExternalAccount.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/entity/ExternalAccount.java
@@ -109,4 +109,9 @@ public class ExternalAccount extends BaseEntity {
         clearOAuthState();
     }
 
+    public void disconnect() {
+        this.status = ExternalAccountStatus.DISCONNECTED;
+        this.accessToken = null;
+        this.refreshToken = null;
+    }
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ExternalAccountRepository.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ExternalAccountRepository.java
@@ -6,6 +6,7 @@ import com.example.todayserver.domain.schedule.connect.enums.ExternalAccountStat
 import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ExternalAccountRepository extends JpaRepository<ExternalAccount, Long> {
@@ -20,4 +21,5 @@ public interface ExternalAccountRepository extends JpaRepository<ExternalAccount
 
     Optional<ExternalAccount> findByProviderAndOauthState(ExternalProvider provider, String oauthState);
 
+    List<ExternalAccount> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ExternalAccountRepository.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/repository/ExternalAccountRepository.java
@@ -22,4 +22,6 @@ public interface ExternalAccountRepository extends JpaRepository<ExternalAccount
     Optional<ExternalAccount> findByProviderAndOauthState(ExternalProvider provider, String oauthState);
 
     List<ExternalAccount> findAllByMemberId(Long memberId);
+
+    List<ExternalAccount> findAllByMemberIdAndStatus(Long memberId, ExternalAccountStatus status);
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/ExternalIntergrationService.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/ExternalIntergrationService.java
@@ -1,0 +1,32 @@
+package com.example.todayserver.domain.schedule.connect.service;
+
+import com.example.todayserver.domain.schedule.connect.converter.ExternalIntegrationConverter;
+import com.example.todayserver.domain.schedule.connect.dto.IntergrationStatueRes;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalAccountStatus;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.repository.ExternalAccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ExternalIntergrationService {
+
+    private final ExternalAccountRepository externalAccountRepository;
+    private final ExternalIntegrationConverter externalIntegrationConverter;
+
+    @Transactional(readOnly = true)
+    public IntergrationStatueRes getIntegrationStatus(Long memberId) {
+        Set<ExternalProvider> connectedProviders = externalAccountRepository.findAllByMemberId(memberId).stream()
+                .filter(a -> a.getStatus() == ExternalAccountStatus.CONNECTED)
+                .map(ExternalAccount::getProvider)
+                .collect(Collectors.toSet());
+
+        return externalIntegrationConverter.toStatusRes(connectedProviders);
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/ExternalIntergrationService.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/ExternalIntergrationService.java
@@ -1,11 +1,14 @@
 package com.example.todayserver.domain.schedule.connect.service;
 
 import com.example.todayserver.domain.schedule.connect.converter.ExternalIntegrationConverter;
+import com.example.todayserver.domain.schedule.connect.dto.IntegrationStatusUpdateReq;
 import com.example.todayserver.domain.schedule.connect.dto.IntergrationStatueRes;
 import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
 import com.example.todayserver.domain.schedule.connect.enums.ExternalAccountStatus;
 import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
 import com.example.todayserver.domain.schedule.connect.repository.ExternalAccountRepository;
+import com.example.todayserver.global.common.exception.CustomException;
+import com.example.todayserver.global.common.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,5 +31,18 @@ public class ExternalIntergrationService {
                 .collect(Collectors.toSet());
 
         return externalIntegrationConverter.toStatusRes(connectedProviders);
+    }
+
+    @Transactional
+    public void disconnect(Long memberId, IntegrationStatusUpdateReq req) {
+        if (req.connected()) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        ExternalAccount account = externalAccountRepository
+                .findByMemberIdAndProvider(memberId, req.provider())
+                .orElseThrow(() -> new CustomException(ErrorCode.EXTERNAL_ACCOUNT_NOT_FOUND));
+
+        account.disconnect();
     }
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/repository/ScheduleRepository.java
@@ -22,6 +22,14 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             LocalDateTime startedAtTo
     );
 
+    // 월별 일정 데이터 전체 조회 (허용된 source 목록 기반으로 조회)
+    List<Schedule> findByMemberIdAndScheduleTypeAndStartedAtBetweenAndSourceIn(
+            Long memberId,
+            ScheduleType scheduleType,
+            LocalDateTime startedAtFrom,
+            LocalDateTime startedAtTo,
+            List<ScheduleSource> sources
+    );
 
     // 월별 일정 데이터 필터 조회
     List<Schedule> findByMemberIdAndScheduleTypeAndStartedAtBetweenAndSource(
@@ -32,24 +40,27 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
             ScheduleSource source
     );
 
-    // 월별 총 일정 개수 조회
-    long countByMemberIdAndScheduleTypeAndStartedAtBetween(
+    // 월별 총 일정 개수 조회 (허용된 source 목록 기반으로 조회
+    long countByMemberIdAndScheduleTypeAndStartedAtBetweenAndSourceIn(
             Long memberId,
             ScheduleType scheduleType,
             LocalDateTime startedAtFrom,
-            LocalDateTime startedAtTo
+            LocalDateTime startedAtTo,
+            List<ScheduleSource> sources
     );
 
-    // 월별 완료된 일정 총 개수 조회
-    long countByMemberIdAndScheduleTypeAndStartedAtBetweenAndIsDoneTrue(
+    // 월별 완료된 일정 총 개수 조회 (허용된 source 목록 기반으로 조회)
+    long countByMemberIdAndScheduleTypeAndStartedAtBetweenAndIsDoneTrueAndSourceIn(
             Long memberId,
             ScheduleType scheduleType,
             LocalDateTime startedAtFrom,
-            LocalDateTime startedAtTo
+            LocalDateTime startedAtTo,
+            List<ScheduleSource> sources
     );
+
 
     // scheduleId와 memberId가 모두 일치하는 Schedule을 조회 (존재 + 소유권 검증을 한 번에 처리).
-    Optional<Schedule> findByIdAndMember_Id(Long id, Long memberId);
+    Optional<Schedule> findByIdAndMember_Id(Long id, Long memberId);/**/
 
     // 내 일정/할 일 목록을 조건(완료여부/타입/날짜/키워드)으로 필터링해서 조회
     @Query("""


### PR DESCRIPTION
## 관련 이슈
#40 
<br>

## 작업 내용
- 외부 연동 상태 조회 API 구현
- 외부 연동 해지 API 구현
- 월별 일정, 완료 현황 조회시 외부 연동 상태(ExternalAccountStatus) = CONNECTED 인것만 조회 되도록 수정
<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
