### PR TITLE
[Feat] iCloud 캘린더 연동 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,10 @@ dependencies {
     // aws
     implementation platform("software.amazon.awssdk:bom:2.25.64")
     implementation "software.amazon.awssdk:s3"
-    
+
+	// ical
+	implementation("org.mnode.ical4j:ical4j:3.2.9")
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalIntegrationController.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/controller/ExternalIntegrationController.java
@@ -1,11 +1,9 @@
 package com.example.todayserver.domain.schedule.connect.controller;
 
-import com.example.todayserver.domain.schedule.connect.dto.GoogleAuthorizeUrlRes;
-import com.example.todayserver.domain.schedule.connect.dto.IntegrationStatusUpdateReq;
-import com.example.todayserver.domain.schedule.connect.dto.IntergrationStatueRes;
-import com.example.todayserver.domain.schedule.connect.dto.NotionAuthorizeUrlRes;
+import com.example.todayserver.domain.schedule.connect.dto.*;
 import com.example.todayserver.domain.schedule.connect.service.ExternalIntergrationService;
 import com.example.todayserver.domain.schedule.connect.service.google.GoogleConnectService;
+import com.example.todayserver.domain.schedule.connect.service.icloud.IcloudConnectService;
 import com.example.todayserver.domain.schedule.connect.service.notion.NotionConnectService;
 import com.example.todayserver.global.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +22,7 @@ public class ExternalIntegrationController {
     private final GoogleConnectService googleConnectService;
     private final NotionConnectService notionConnectService;
     private final ExternalIntergrationService externalIntergrationService;
+    private final IcloudConnectService icloudConnectService;
 
     @Operation(
             summary = "외부 연동 상태 조회",
@@ -110,6 +109,19 @@ public class ExternalIntegrationController {
             String state
     ) {
         notionConnectService.handleCallback(code, state);
+        return ApiResponse.success(null);
+    }
+
+    @Operation(
+            summary = "iCloud 캘린더 연동 API",
+            description = "ics 링크를 기반으로 사용자의 iCloud 일정을 연동합니다."
+    )
+    @PostMapping("/icloud/connections")
+    public ApiResponse<Void> connectIcloud(
+            @AuthenticationPrincipal(expression = "id") Long memberId,
+            @RequestBody IcloudIntergrationsReq req
+    ) {
+        icloudConnectService.connectAndSync(memberId, req);
         return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/converter/ScheduleConverter.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/converter/ScheduleConverter.java
@@ -48,6 +48,7 @@ public class ScheduleConverter {
                 .repeatType(null)
                 .durationMinutes(null)
                 .isDone(false)
+                .isAllDay(event.allDay())
                 .build();
     }
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/converter/ScheduleExternalConverter.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/converter/ScheduleExternalConverter.java
@@ -20,13 +20,17 @@ public class ScheduleExternalConverter {
             Schedule schedule,
             ScheduleExternalVersionType versionType
     ) {
+        var originUpdatedAt = event.originUpdatedAt() != null
+                ? event.originUpdatedAt()
+                : (event.startedAt() != null ? event.startedAt() : java.time.LocalDateTime.now());
+
         return ScheduleExternal.builder()
                 .externalSource(source)
                 .schedule(schedule)
                 .externalEventId(event.externalEventId())
                 .versionType(versionType)
                 .versionKey(buildVersionKey(event, versionType))
-                .originUpdatedAt(event.originUpdatedAt())
+                .originUpdatedAt(originUpdatedAt)
                 .build();
     }
 

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/dto/IcloudIntergrationsReq.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/dto/IcloudIntergrationsReq.java
@@ -1,0 +1,12 @@
+package com.example.todayserver.domain.schedule.connect.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record IcloudIntergrationsReq(
+        @Schema(
+                description = "icloud 캘린더 공유 링크(ICS)",
+                example = "webcal://p149-caldav.icloud.com/published..."
+        )
+        String icsUrl
+) {
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/entity/ExternalAccount.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/entity/ExternalAccount.java
@@ -5,6 +5,8 @@ import com.example.todayserver.domain.schedule.connect.enums.ExternalAccountStat
 import com.example.todayserver.domain.schedule.connect.enums.ExternalAuthType;
 import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
 import com.example.todayserver.global.common.entity.BaseEntity;
+import com.example.todayserver.global.common.exception.CustomException;
+import com.example.todayserver.global.common.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -39,6 +41,10 @@ public class ExternalAccount extends BaseEntity {
     @Lob
     @Column(name = "refresh_token",  nullable = true)
     private String refreshToken;
+
+    @Lob
+    @Column(name = "ics_url", nullable = true)
+    private String icsUrl;
 
     @Column(name = "expired_at",  nullable = true)
     private LocalDateTime expiredAt;
@@ -113,5 +119,14 @@ public class ExternalAccount extends BaseEntity {
         this.status = ExternalAccountStatus.DISCONNECTED;
         this.accessToken = null;
         this.refreshToken = null;
+        this.icsUrl = null;
     }
+
+    public void updateIcsUrl(String icsUrl) {
+        if (icsUrl == null || icsUrl.isBlank()) {
+            throw new CustomException(ErrorCode.EXTERNAL_CALENDAR_INVALID_URL);
+        }
+        this.icsUrl = icsUrl;
+    }
+
 }

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/icloud/IcloudCalendarClient.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/icloud/IcloudCalendarClient.java
@@ -1,0 +1,127 @@
+package com.example.todayserver.domain.schedule.connect.service.icloud;
+
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalSourceDto;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalSource;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalCalendarClient;
+import com.example.todayserver.global.common.exception.CustomException;
+import com.example.todayserver.global.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+public class IcloudCalendarClient implements ExternalCalendarClient {
+    private final IcloudIcsEventParser icsEventParser;
+
+    @Qualifier("icloudWebClient")
+    private final WebClient webClient;
+
+    public IcloudCalendarClient(
+            @Qualifier("icloudWebClient") WebClient webClient,
+            IcloudIcsEventParser icsEventParser
+    ) {
+        this.webClient = webClient;
+        this.icsEventParser = icsEventParser;
+    }
+
+    @Override
+    public ExternalProvider provider() {
+        return ExternalProvider.ICLOUD;
+    }
+
+    @Override
+    public List<ExternalSourceDto> fetchSources(ExternalAccount account) {
+        return List.of(
+                new ExternalSourceDto(
+                        "ICLOUD_ICS_DEFAULT",
+                        "iCloud(ICS)",
+                        null
+                )
+        );
+    }
+
+    @Override
+    public List<ExternalEventDto> fetchEvents(
+            ExternalAccount account,
+            ExternalSource source,
+            LocalDateTime from,
+            LocalDateTime to
+    ) {
+        String icsUrl = extractIcsUrl(account);
+        String normalized = normalizeIcsUrl(icsUrl);
+
+        var resp = webClient.get()
+                .uri(normalized)
+                .accept(MediaType.parseMediaType("text/calendar"))
+                .header("User-Agent", "Mozilla/5.0")
+                .exchangeToMono(r -> r.toEntity(String.class))
+                .block();
+
+        if (resp == null) throw new CustomException(ErrorCode.EXTERNAL_CALENDAR_FETCH_FAILED);
+
+        String contentType = (resp.getHeaders().getContentType() != null)
+                ? resp.getHeaders().getContentType().toString()
+                : "null";
+
+        String body = resp.getBody();
+
+        if (!resp.getStatusCode().is2xxSuccessful()) {
+            throw new CustomException(ErrorCode.EXTERNAL_CALENDAR_FETCH_FAILED);
+        }
+        if (body == null || body.isBlank()) {
+            throw new CustomException(ErrorCode.EXTERNAL_CALENDAR_FETCH_FAILED);
+        }
+
+        if (!body.contains("BEGIN:VCALENDAR")) {
+            throw new CustomException(ErrorCode.EXTERNAL_CALENDAR_FETCH_FAILED);
+        }
+
+        return icsEventParser.parse(body, from, to);
+    }
+
+
+    private String extractIcsUrl(ExternalAccount account) {
+        if (account == null) {
+            throw new CustomException(ErrorCode.EXTERNAL_ACCOUNT_NOT_FOUND);
+        }
+
+        String url = account.getIcsUrl();
+        if (url == null || url.isBlank()) {
+            throw new CustomException(ErrorCode.EXTERNAL_CALENDAR_INVALID_URL);
+        }
+
+        return url;
+    }
+
+    private String normalizeIcsUrl(String url) {
+        if (url == null) {
+            throw new CustomException(ErrorCode.EXTERNAL_CALENDAR_INVALID_URL);
+        }
+
+        String normalized = url
+                .replace("\u200B", "")   // zero-width space
+                .replace("\uFEFF", "")   // BOM
+                .replaceAll("\\s+", "")  // 모든 공백/개행/탭 제거
+                .trim();
+
+        if (normalized.startsWith("webcal://")) {
+            normalized = "https://" + normalized.substring("webcal://".length());
+        }
+
+        if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+            throw new CustomException(ErrorCode.EXTERNAL_CALENDAR_INVALID_URL);
+        }
+
+        return normalized;
+    }
+
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/icloud/IcloudConnectService.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/icloud/IcloudConnectService.java
@@ -1,0 +1,52 @@
+package com.example.todayserver.domain.schedule.connect.service.icloud;
+
+import com.example.todayserver.domain.member.entity.Member;
+import com.example.todayserver.domain.member.excpetion.code.MemberErrorCode;
+import com.example.todayserver.domain.member.repository.MemberRepository;
+import com.example.todayserver.domain.schedule.connect.dto.IcloudIntergrationsReq;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalAccount;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalAccountStatus;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalAuthType;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import com.example.todayserver.domain.schedule.connect.repository.ExternalAccountRepository;
+import com.example.todayserver.domain.schedule.connect.service.ExternalSyncService;
+import com.example.todayserver.global.common.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.YearMonth;
+
+@Service
+@RequiredArgsConstructor
+public class IcloudConnectService {
+
+    private final ExternalAccountRepository externalAccountRepository;
+    private final MemberRepository memberRepository;
+    private final ExternalSyncService externalSyncService;
+
+    @Transactional
+    public void connectAndSync(Long memberId, IcloudIntergrationsReq req) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(MemberErrorCode.NOT_FOUND));
+
+        ExternalAccount account = externalAccountRepository
+                .findByMemberIdAndProvider(memberId, ExternalProvider.ICLOUD)
+                .orElseGet(() -> ExternalAccount.builder()
+                        .member(member)
+                        .provider(ExternalProvider.ICLOUD)
+                        .authType(ExternalAuthType.ICS)
+                        .status(ExternalAccountStatus.CONNECTED)
+                        .build()
+                );
+
+        account.updateIcsUrl(req.icsUrl());
+
+        externalAccountRepository.save(account);
+
+        // 일정 동기화
+        YearMonth now = YearMonth.now();
+        externalSyncService.syncMonth(memberId, ExternalProvider.ICLOUD, now.getYear(), now.getMonthValue());
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/icloud/IcloudEventMapper.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/icloud/IcloudEventMapper.java
@@ -1,0 +1,41 @@
+package com.example.todayserver.domain.schedule.connect.service.icloud;
+
+import com.example.todayserver.domain.member.entity.Member;
+import com.example.todayserver.domain.schedule.connect.converter.ScheduleConverter;
+import com.example.todayserver.domain.schedule.connect.converter.ScheduleExternalConverter;
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.domain.schedule.connect.entity.ExternalSource;
+import com.example.todayserver.domain.schedule.connect.entity.ScheduleExternal;
+import com.example.todayserver.domain.schedule.connect.enums.ScheduleExternalVersionType;
+import com.example.todayserver.domain.schedule.connect.service.core.ExternalEventMapper;
+import com.example.todayserver.domain.schedule.entity.Schedule;
+import com.example.todayserver.domain.schedule.enums.ScheduleSource;
+import com.example.todayserver.domain.schedule.connect.enums.ExternalProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IcloudEventMapper implements ExternalEventMapper {
+
+    @Override
+    public ExternalProvider provider() {
+        return ExternalProvider.ICLOUD;
+    }
+
+    @Override
+    public ScheduleExternalVersionType versionType() {
+        return ScheduleExternalVersionType.HASH;
+    }
+
+    @Override
+    public Schedule toSchedule(ExternalEventDto event, Member member) {
+        ScheduleSource source = ScheduleSource.ICLOUD;
+        return ScheduleConverter.fromExternalEvent(event, member, source);
+    }
+
+    @Override
+    public ScheduleExternal toScheduleExternal(ExternalEventDto event, ExternalSource source, Schedule schedule) {
+        return ScheduleExternalConverter.newMapping(event, source, schedule, versionType());
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/connect/service/icloud/IcloudIcsEventParser.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/connect/service/icloud/IcloudIcsEventParser.java
@@ -1,0 +1,126 @@
+package com.example.todayserver.domain.schedule.connect.service.icloud;
+
+import com.example.todayserver.domain.schedule.connect.dto.ExternalEventDto;
+import com.example.todayserver.global.common.exception.CustomException;
+import com.example.todayserver.global.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import net.fortuna.ical4j.data.CalendarBuilder;
+import net.fortuna.ical4j.model.Component;
+import net.fortuna.ical4j.model.DateTime;
+import net.fortuna.ical4j.model.component.VEvent;
+import net.fortuna.ical4j.model.property.DtEnd;
+import net.fortuna.ical4j.model.property.DtStart;
+
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@org.springframework.stereotype.Component
+public class IcloudIcsEventParser {
+
+    public List<ExternalEventDto> parse(String icsText, LocalDateTime from, LocalDateTime to) {
+        try {
+            var calendar = new CalendarBuilder().build(new StringReader(icsText));
+            ZoneId zone = ZoneId.of("Asia/Seoul");
+
+            LocalDate fromDate = from.toLocalDate();
+            LocalDate toDate = to.toLocalDate();
+
+            List<ExternalEventDto> results = new ArrayList<>();
+
+            @SuppressWarnings("unchecked")
+            List<VEvent> events = calendar.getComponents(Component.VEVENT);
+
+            for (VEvent e : events) {
+
+                DtStart start = e.getStartDate();
+                if (start == null) continue;
+
+                DtEnd end = e.getEndDate();
+                boolean allDay = !(start.getDate() instanceof DateTime);
+
+                LocalDateTime startedAt;
+                LocalDateTime endedAt;
+
+                if (allDay) {
+                    LocalDate sd = Instant.ofEpochMilli(start.getDate().getTime())
+                            .atZone(zone).toLocalDate();
+
+                    LocalDate ed = end != null
+                            ? Instant.ofEpochMilli(end.getDate().getTime())
+                            .atZone(zone).toLocalDate()
+                            : sd.plusDays(1);
+
+                    if (ed.isBefore(fromDate) || sd.isAfter(toDate)) continue;
+
+                    startedAt = sd.atStartOfDay();
+                    endedAt = ed.atStartOfDay();
+                } else {
+                    startedAt = Instant.ofEpochMilli(start.getDate().getTime())
+                            .atZone(zone).toLocalDateTime();
+
+                    endedAt = end != null
+                            ? Instant.ofEpochMilli(end.getDate().getTime())
+                            .atZone(zone).toLocalDateTime()
+                            : null;
+
+                    if (startedAt.isAfter(to) || (endedAt != null && endedAt.isBefore(from))) continue;
+                }
+
+                String uid = e.getUid() != null
+                        ? e.getUid().getValue()
+                        : UUID.randomUUID().toString();
+
+                String title = e.getSummary() != null
+                        ? e.getSummary().getValue()
+                        : "(제목 없음)";
+
+                String desc = e.getDescription() != null
+                        ? e.getDescription().getValue()
+                        : null;
+
+                LocalDateTime updatedAt = null;
+                if (e.getLastModified() != null) {
+                    updatedAt = Instant.ofEpochMilli(e.getLastModified().getDate().getTime())
+                            .atZone(zone).toLocalDateTime();
+                }
+
+                String versionKey = sha256(uid + "|" + title + "|" + startedAt + "|" + endedAt);
+
+                results.add(new ExternalEventDto(
+                        uid + "#" + startedAt,
+                        title,
+                        desc,
+                        startedAt,
+                        endedAt,
+                        allDay,
+                        updatedAt,
+                        versionKey,
+                        null
+                ));
+            }
+
+            return results;
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.EXTERNAL_CALENDAR_PARSE_FAILED);
+        }
+    }
+
+    private String sha256(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] d = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : d) sb.append(String.format("%02x", b));
+            return sb.toString();
+        } catch (Exception e) {
+            return input;
+        }
+    }
+}

--- a/src/main/java/com/example/todayserver/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/example/todayserver/domain/schedule/entity/Schedule.java
@@ -66,6 +66,9 @@ public class Schedule extends BaseEntity {
     @Column(name = "is_done", nullable = false)
     private boolean isDone;
 
+    @Column(name = "is_all_day", nullable = false)
+    private boolean isAllDay;
+
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;

--- a/src/main/java/com/example/todayserver/global/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/todayserver/global/common/exception/ErrorCode.java
@@ -25,15 +25,19 @@ public enum ErrorCode implements BaseErrorCode {
 
     // External
     EXTERNAL_OAUTH_STATE_INVALID(HttpStatus.BAD_REQUEST, "EXTERNAL400_1", "외부 연동 state 값이 올바르지 않습니다."),
-    EXTERNAL_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "EXTERNAL404_1", "연결된 외부 계정을 찾을 수 없습니다."),
     EXTERNAL_ACCOUNT_INACTIVE(HttpStatus.BAD_REQUEST, "EXTERNAL400_2", "비활성화된 외부 계정입니다."),
     EXTERNAL_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "EXTERNAL400_3", "지원하지 않는 외부 연동 제공자입니다."),
+    EXTERNAL_ACCESS_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "EXTERNAL400_4", "외부 연동 계정의 액세스 토큰이 존재하지 않습니다."),
+    EXTERNAL_CALENDAR_INVALID_URL(HttpStatus.BAD_REQUEST, "EXTERNAL400_5", "ICS URL 형식이 올바르지 않습니다."),
+    EXTERNAL_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "EXTERNAL404_1", "연결된 외부 계정을 찾을 수 없습니다."),
+    EXTERNAL_SOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXTERNAL404_2", "외부 캘린더 소스를 찾을 수 없습니다."),
     EXTERNAL_CLIENT_NOT_REGISTERED(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL500_1", "외부 연동 클라이언트가 등록되지 않았습니다."),
     EXTERNAL_MAPPER_NOT_REGISTERED(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL500_2", "외부 이벤트 매퍼가 등록되지 않았습니다."),
-    EXTERNAL_SOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "EXTERNAL404_2", "외부 캘린더 소스를 찾을 수 없습니다."),
     EXTERNAL_SYNC_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL500_3", "외부 일정 동기화 중 오류가 발생했습니다."),
-    EXTERNAL_ACCESS_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "EXTERNAL400_4", "외부 연동 계정의 액세스 토큰이 존재하지 않습니다."),
-    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL500_4", "외부 캘린더 API 호출 중 오류가 발생했습니다.")
+    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL500_4", "외부 캘린더 API 호출 중 오류가 발생했습니다."),
+    EXTERNAL_CALENDAR_FETCH_FAILED(HttpStatus.BAD_GATEWAY, "EXTERNAL502_1", "외부 캘린더(ICS) 조회에 실패했습니다."),
+    EXTERNAL_CALENDAR_PARSE_FAILED(HttpStatus.BAD_GATEWAY, "EXTERNAL502_2", "외부 캘린더(ICS) 파싱에 실패했습니다."),
+
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/todayserver/global/config/WebClientConfig.java
+++ b/src/main/java/com/example/todayserver/global/config/WebClientConfig.java
@@ -30,6 +30,7 @@ public class WebClientConfig {
                 .build();
     }
 
+    // Google API 전용 WebClient
     @Bean
     public WebClient googleCalendarWebClient() {
         return WebClient.builder()
@@ -48,6 +49,12 @@ public class WebClientConfig {
                 .baseUrl(notionProperties.getApiBase())
                 .defaultHeader("Notion-Version", notionProperties.getVersion())
                 .build();
+    }
+
+    // iCloud 전용 WebClient
+    @Bean
+    public WebClient icloudWebClient(WebClient.Builder builder) {
+        return builder.build();
     }
 
     private HttpClient httpClient() {


### PR DESCRIPTION
## 관련 이슈
#40 
<br>

## 작업 내용
- iCloud 캘린더 연동 API 구현
- 연동 요청시 요청일 앞, 뒤 3개월치 일정 자동 동기화
<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
