### PR TITLE
feat: 비밀번호 잊을 시 재설정 API

### DIFF
--- a/src/main/java/com/example/todayserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/todayserver/domain/member/controller/MemberController.java
@@ -47,6 +47,13 @@ public class MemberController implements MemberControllerDocs {
         return ApiResponse.success(null);
     }
 
+    @PatchMapping("/password/reset")
+    public ApiResponse<Void> updatePasswordRest(@Valid @RequestBody MemberReqDto.LoginDto dto){
+        memberService.updatePasswordReset(dto.getPassword(), dto.getEmail());
+        return ApiResponse.success(null);
+    }
+
+
     @PatchMapping(value = "/profile",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Void> updateProfile(@RequestHeader("Authorization") String token, @ModelAttribute MemberReqDto.ProfileInfo dto){

--- a/src/main/java/com/example/todayserver/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/com/example/todayserver/domain/member/controller/MemberControllerDocs.java
@@ -36,11 +36,18 @@ public interface MemberControllerDocs {
     ApiResponse<Void> withdraw(@RequestHeader("Authorization") String token);
 
     @Operation(
-            summary = "비밀번호 재설정",
+            summary = "비밀번호 변경",
             description = "비밀 번호를 변경합니다."
     )
     ApiResponse<Void> updatePassword(@RequestHeader("Authorization") String token, @Valid @RequestBody MemberReqDto.Password dto);
 
+
+    @Operation(
+            summary = "비밀번호 재설정",
+            description = "비밀 번호를 잊은 경우 재설정합니다."
+    )
+    ApiResponse<Void> updatePasswordRest(@Valid @RequestBody MemberReqDto.LoginDto dto);
+    
     @Operation(
             summary = "프로필 정보 수정 API",
             description = "닉네임과 프로필 사진을 수정합니다."

--- a/src/main/java/com/example/todayserver/domain/member/repository/EmailCodeRepository.java
+++ b/src/main/java/com/example/todayserver/domain/member/repository/EmailCodeRepository.java
@@ -3,11 +3,16 @@ package com.example.todayserver.domain.member.repository;
 import com.example.todayserver.domain.member.entity.EmailVerification;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface EmailCodeRepository extends JpaRepository<EmailVerification, Long> {
     Optional<EmailVerification> findByEmailAndCode(
             String email, String verificationCode);
-    boolean existsByEmailAndVerifiedIsTrue(String email);
+    boolean existsByEmailAndVerifiedIsTrueAndExpireDateAfter(
+            String email,
+            LocalDateTime now
+    );
+
     void deleteByEmail(String email);
 }

--- a/src/main/java/com/example/todayserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/todayserver/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.example.todayserver.domain.member.service;
 import com.example.todayserver.domain.member.dto.MemberReqDto;
 import com.example.todayserver.domain.member.dto.MemberResDto;
 import com.example.todayserver.domain.member.entity.Member;
+import jakarta.transaction.Transactional;
 
 public interface MemberService {
 
@@ -14,5 +15,9 @@ public interface MemberService {
     MemberResDto.MemberInfo getMyInfo(String token);
     void withdraw(String token);
     void updatePassword(String password, String token);
+
+    @Transactional
+    void updatePasswordReset(String password, String token);
+
     void updateProfile(String token, MemberReqDto.ProfileInfo dto);
 }

--- a/src/main/java/com/example/todayserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/todayserver/global/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/swagger-resources/**",
             "/v3/api-docs/**",
-            "/api/members/password",
+            "/api/members/password/reset",
             "/api/auth/**",
             "/api/oauth2/**"
     };


### PR DESCRIPTION
## 관련 이슈
> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

<br>

## 작업 내용
비밀번호 잊을 시 재설정 API
기존에는 토큰이 필수인 버전만 있었으나 비밀번호를 잊어서 재설정하는 경우 토큰이 없기에 이메일 인증 후 재설정을 할 수 있게 API 추가 구현

<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
