### PR TITLE
feat: 인증 실패 시 응답 추가

### DIFF
--- a/src/main/java/com/example/todayserver/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/todayserver/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.example.todayserver.global.common.jwt.JwtAuthFilter;
 import com.example.todayserver.global.common.jwt.JwtUtil;
 import com.example.todayserver.global.oauth.OAuth2SuccessHandler;
 import com.example.todayserver.global.oauth.OAuth2UserCustomService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,6 +42,17 @@ public class SecurityConfig {
                         .requestMatchers(allowUris).permitAll()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write("""
+                    {
+                      "code": "LOGIN_REQUIRED",
+                      "message": "로그인이 필요한 서비스입니다."
+                    }
+                    """);
+                }))
                 // 폼로그인 비활성화
                 .formLogin(AbstractHttpConfigurer::disable)
                 .addFilterBefore(jwtAuthFilter(), UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## 관련 이슈
> 관련된 이슈 번호를 적어주세요. 예: #이슈번호

<br>

## 작업 내용
현재 인증 인가 실패 시 시큐리티 기본 제공 로그인 html이 반환되는 것 같습니다. jwt 필터 단 에러 발생 시 적절한 오류 처리를 해주시면 좋을 것 같습니다.
-> 1차 피드백에 맞게 인증 실패 시 응답 추가하였습니다.

<br>
<img width="452" height="134" alt="image" src="https://github.com/user-attachments/assets/821c0900-9a51-41e4-b1a7-0c25221d9816" />

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
