### PR TITLE
[Chore] 도메인, HTTPS 적용에 따른 Docker 포트 및 배포 구조 변경

### DIFF
--- a/.github/workflows/depoly.yml
+++ b/.github/workflows/depoly.yml
@@ -48,7 +48,7 @@ jobs:
             sudo docker stop today-container || true
             sudo docker rm today-container || true
             sudo docker run -d --name today-container \
-              -p 80:8080 \
+              -p 127.0.0.1:8080:8080 \
               -e DB_URL="${{ secrets.DB_URL }}" \
               -e DB_USERNAME="${{ secrets.DB_USERNAME }}" \
               -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \


### PR DESCRIPTION
## 관련 이슈
#88 
<br>

## 작업 내용
- 도메인 연결 및 HTTPS 적용을 위해 Nginx 리버스 프록시 구조를 도입하고, 이에 따라 백엔드 Docker 컨테이너의 포트 바인딩 방식을 변경함
- 기존 80:8080 직접 노출 구조에서 Nginx(80/443) → Docker(127.0.0.1:8080) 구조로 변경
<br>

## 기타 (선택)
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
